### PR TITLE
feat: single `export` declaration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ ImplementationFileExtensions:
 HeaderFilterRegex: ""
 ExcludeHeaderFilterRegex: ""
 FormatStyle: none
-User: qliu23
 CheckOptions:
   cert-arr39-c.WarnOnSizeOfCompareToConstant: "false"
   cert-arr39-c.WarnOnSizeOfConstant: "false"

--- a/example/08.imports.ng
+++ b/example/08.imports.ng
@@ -1,4 +1,6 @@
 
-import "external" ext;
+import external (*);
 
-ext.hello();
+hello();
+
+hello2();

--- a/example/external.ng
+++ b/example/external.ng
@@ -1,5 +1,11 @@
-module external exports *;
+module external exports (
+    hello
+);
 
 fun hello() {
     print("Hello");
+}
+
+export fun hello2() {
+    print("Hello2");
 }

--- a/lib/std.ng
+++ b/lib/std.ng
@@ -1,3 +1,1 @@
-module std exports (
-    printList
-);
+module std;

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -546,7 +546,6 @@ namespace NG::intp
 
         void visit(CompileUnit *compileUnit) override
         {
-            debug_log("Visiting module", compileUnit->module->name);
             if (!compileUnit->path.empty())
             {
                 context->appendModulePath(compileUnit->path);

--- a/test/parsing/parser_test.cpp
+++ b/test/parsing/parser_test.cpp
@@ -344,3 +344,30 @@ TEST_CASE("Regex match", "[ParserTestRegexMatch]")
     match(pattern, "0a", false);
     match(pattern, "-a", false);
 }
+
+TEST_CASE("Should export single declaration", "[ParserTest]")
+{
+    auto astResult = parse(R"(
+export val x = 1;
+
+export fun get() = native;
+
+export type Simple {}
+)");
+
+    REQUIRE(astResult.has_value());
+    destroyast(*astResult);
+}
+
+TEST_CASE("Should not export statement", "[ParserTest]")
+{
+    auto astResult = parse(R"(
+
+export loop x = 1 {
+}
+
+)");
+
+    REQUIRE(!astResult.has_value());
+    // destroyast(*astResult);
+}


### PR DESCRIPTION
## Example usage

```
module <something> exports (
   <exports declarations>
);

export <some value / fun / type declaration>;
```

Every single `export <declaration>` will be merged with `exports` declaration list.

## Out of scope

You can only `export` values, functions and types.

Export simple identifiers and imports are not supported yet.