### PR TITLE
unary expression interpret and check (resolve #14), and multiline comment / shebang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(NG_TEST_SRC
         test/typecheck/typeinfo_function_test.cpp
         test/typecheck/typecheck_primitive_test.cpp
         test/typecheck/typecheck_function_test.cpp
+        test/typecheck/typecheck_expression_test.cpp
         )
 
 

--- a/example/11.iterator_example.ng
+++ b/example/11.iterator_example.ng
@@ -23,13 +23,11 @@ type List {
         print("append", value, self);
         self.size = self.size + 1;
         if (self.node is None) {
-            print("append to none", value, self);
             self.node = new Node {
                 _next: new None {},
                 content: value
             };
         } else if (!self.node.hasNext()) {
-            print("append to first", value, self);
             self.node._next = new Node {
                 _next: new None {},
                 content: value
@@ -40,7 +38,6 @@ type List {
                     current = current.getNext();
 
                     if (!current.hasNext()) {
-                        print("append to last", value, self);
                         current._next = new Node {
                             _next: current._next,
                             content: value

--- a/example/11.iterator_example.ng
+++ b/example/11.iterator_example.ng
@@ -20,13 +20,16 @@ type List {
     property size;
 
     fun append(value) {
+        print("append", value, self);
         self.size = self.size + 1;
         if (self.node is None) {
+            print("append to none", value, self);
             self.node = new Node {
                 _next: new None {},
                 content: value
             };
-        } else if (not(self.node.hasNext())) {
+        } else if (!self.node.hasNext()) {
+            print("append to first", value, self);
             self.node._next = new Node {
                 _next: new None {},
                 content: value
@@ -36,7 +39,8 @@ type List {
                 if (current.hasNext()) {
                     current = current.getNext();
 
-                    if (not(current.hasNext())) {
+                    if (!current.hasNext()) {
+                        print("append to last", value, self);
                         current._next = new Node {
                             _next: current._next,
                             content: value
@@ -50,7 +54,7 @@ type List {
     }
 
     fun hasNext() {
-        return not(self.node is None);
+        return !(self.node is None);
     }
 
     fun getNext() {

--- a/example/shebang.ng
+++ b/example/shebang.ng
@@ -1,0 +1,3 @@
+#!./ngi
+
+print("hello");

--- a/include/intp/runtime_numerals.hpp
+++ b/include/intp/runtime_numerals.hpp
@@ -65,7 +65,12 @@ namespace NG::runtime
          * @return The result of the modulus operation.
          */
         virtual auto opModulus(const NumeralBase *other) const -> RuntimeRef<NGObject> = 0;
-
+        /**
+         * @brief Computes the negate of this numeral.
+         *
+         * @return The result of the negate operation.
+         */
+        virtual auto opNegate() const -> RuntimeRef<NGObject> = 0;
         NumeralBase() = default;
 
         NumeralBase(const NumeralBase &) = delete;
@@ -198,6 +203,8 @@ namespace NG::runtime
         [[nodiscard]] auto opModulus(RuntimeRef<NGObject> other) const -> RuntimeRef<NGObject> override;
 
         auto opModulus(const NumeralBase *other) const -> RuntimeRef<NGObject> override;
+
+        auto opNegate() const -> RuntimeRef<NGObject> override;
 
         /**
          * @brief Returns the value as a `size_t`.
@@ -346,6 +353,16 @@ namespace NG::runtime
         return makert<NGIntegral<T>>(value % d);
     }
 
+    template <std::integral T>
+    auto NGIntegral<T>::opNegate() const -> RuntimeRef<NGObject>
+    {
+        if (signedness())
+        {
+            return makert<NGIntegral<T>>(-value);
+        }
+        throw RuntimeException("Cannot negate unsigned integers");
+    }
+
 #pragma endregion
 
 #pragma region Runtime FloatingPoints
@@ -461,6 +478,8 @@ namespace NG::runtime
         [[nodiscard]] auto opModulus(RuntimeRef<NGObject> other) const -> RuntimeRef<NGObject> override;
 
         auto opModulus(const NumeralBase *other) const -> RuntimeRef<NGObject> override;
+
+        auto opNegate() const -> RuntimeRef<NGObject> override;
 
         /**
          * @brief Returns the value as a `size_t`.
@@ -591,6 +610,12 @@ namespace NG::runtime
     auto NGFloatingPoint<T>::opModulus(const NumeralBase *other) const -> RuntimeRef<NGObject>
     {
         throw std::logic_error("floating point not support modulus operation");
+    }
+
+    template <std::floating_point T>
+    auto NGFloatingPoint<T>::opNegate() const -> RuntimeRef<NGObject>
+    {
+        return makert<NGFloatingPoint<T>>(-value);
     }
 
 #pragma endregion

--- a/include/intp/runtime_numerals.hpp
+++ b/include/intp/runtime_numerals.hpp
@@ -2,6 +2,7 @@
 
 #include <intp/runtime.hpp>
 #include <cmath>
+#include <limits>
 
 namespace NG::runtime
 {
@@ -348,7 +349,7 @@ namespace NG::runtime
         const auto d = NGIntegral<T>(other).value;
         if (d == 0)
         {
-            throw RuntimeException("Division by zero");
+            throw RuntimeException("Modulus by zero");
         }
         return makert<NGIntegral<T>>(value % d);
     }
@@ -358,6 +359,11 @@ namespace NG::runtime
     {
         if (signedness())
         {
+            using Lim = std::numeric_limits<T>;
+            if (value == Lim::min())
+            {
+                throw RuntimeException("Overflow on negation");
+            }
             return makert<NGIntegral<T>>(-value);
         }
         throw RuntimeException("Cannot negate unsigned integers");

--- a/include/module.hpp
+++ b/include/module.hpp
@@ -29,12 +29,12 @@ namespace NG::module
      */
     struct ModuleInfo
     {
-        Str moduleId; ///< The unique ID of the module.
-        Str moduleAbsolutePath; ///< The absolute path to the module.
-        Str moduleName; ///< The name of the module.
-        Str moduleLoadingLocation; ///< The location from which the module was loaded.
-        ASTRef<NG::ast::ASTNode> moduleAst; ///< The AST of the module.
-        Str moduleSource; ///< The source code of the module.
+        Str moduleId;                                    ///< The unique ID of the module.
+        Str moduleName;                                  ///< The name of the module.
+        Str moduleSource;                                ///< The source code of the module.
+        ASTRef<NG::ast::ASTNode> moduleAst;              ///< The AST of the module.
+        Str moduleAbsolutePath;                          ///< The absolute path to the module.
+        Str moduleLoadingLocation;                       ///< The location from which the module was loaded.
         RuntimeRef<NG::runtime::NGModule> runtimeModule; ///< The runtime representation of the module.
     };
 
@@ -44,7 +44,7 @@ namespace NG::module
     class ModuleRegistry : NonCopyable
     {
         Map<Str, RuntimeRef<ModuleInfo>> modules; ///< The modules in the registry.
-        Vec<Str> basePaths; ///< The base paths for module resolution.
+        Vec<Str> basePaths;                       ///< The base paths for module resolution.
 
     public:
         ModuleRegistry(Map<Str, RuntimeRef<ModuleInfo>> modules, Vec<Str> basePaths)

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -153,6 +153,13 @@ namespace NG::ast
         virtual void visit(TypeCheckingExpression *typeCheck) = 0;
 
         /**
+         * @brief Visits a unary expression.
+         *
+         * @param unoExpr The unary expression to visit.
+         */
+        virtual void visit(UnaryExpression *unoExpr) = 0;
+
+        /**
          * @brief Visits a binary expression.
          *
          * @param binExpr The binary expression to visit.
@@ -308,6 +315,8 @@ namespace NG::ast
         void visit(IndexAssignmentExpression *index) override;
 
         void visit(TypeCheckingExpression *typeCheck) override;
+
+        void visit(UnaryExpression *unoExpr) override;
 
         void visit(BinaryExpression *binExpr) override;
 

--- a/src/ast/AstVisitor.cpp
+++ b/src/ast/AstVisitor.cpp
@@ -14,6 +14,8 @@ namespace NG::ast
 
     void AstVisitor::visit(IdAccessorExpression *idAccExpr) {}
 
+    void AstVisitor::visit(UnaryExpression *unoExpr) {}
+
     void AstVisitor::visit(BinaryExpression *binExpr) {}
 
     void AstVisitor::visit(AssignmentExpression *assignmentExpr) {}

--- a/src/ast/DummyVisitor.cpp
+++ b/src/ast/DummyVisitor.cpp
@@ -14,6 +14,8 @@ namespace NG::ast
 
     void DummyVisitor::visit(IdAccessorExpression *idAccExpr) {}
 
+    void DummyVisitor::visit(UnaryExpression *unoExpr) {}
+
     void DummyVisitor::visit(BinaryExpression *binExpr) {}
 
     void DummyVisitor::visit(AssignmentExpression *assignmentExpr) {}

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -194,6 +194,34 @@ namespace NG::intp
             context->retVal = nullptr;
         }
 
+        void visit(UnaryExpression *unoExpr) override
+        {
+            ExpressionVisitor operandVisitor{context};
+            unoExpr->operand->accept(&operandVisitor);
+            auto result = operandVisitor.object;
+
+            switch (unoExpr->optr->operatorType)
+            {
+            case Operators::MINUS:
+            {
+                auto numeric = dynamic_cast<NumeralBase *>(&(*result));
+                if (numeric)
+                {
+                    this->object = numeric->opNegate();
+                    break;
+                }
+                throw RuntimeException("Cannot negate a non-number");
+            }
+            case Operators::NOT:
+                this->object = NGObject::boolean(!result->boolValue());
+                break;
+            case Operators::QUERY:
+                throw NotImplementedException("Operator QUERY (?) not implemented yet");
+            default:
+                throw RuntimeException("Unsupported Operator");
+            }
+        }
+
         void visit(BinaryExpression *binExpr) override
         {
             ExpressionVisitor leftVisitor{context};

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -204,17 +204,17 @@ namespace NG::intp
             {
             case Operators::MINUS:
             {
-                auto numeric = dynamic_cast<NumeralBase *>(&(*result));
+                auto numeric = dynamic_cast<NumeralBase *>(result.get());
                 if (numeric)
                 {
                     this->object = numeric->opNegate();
-                    break;
+                    return;
                 }
                 throw RuntimeException("Cannot negate a non-number");
             }
             case Operators::NOT:
                 this->object = NGObject::boolean(!result->boolValue());
-                break;
+                return;
             case Operators::QUERY:
                 throw NotImplementedException("Operator QUERY (?) not implemented yet");
             default:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,7 @@ auto repl() -> int
             {
                 continue;
             }
+            // debug_log(current);
             tokens.push_back(current);
             if (current.type == TokenType::LEFT_CURLY)
             {

--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -210,10 +210,26 @@ namespace NG::parsing
                     }
                     state.next();
                 }
+                else if (state.lookAhead() == '*')
+                {
+                    while (!(state.current() == '*' && state.lookAhead() == '/'))
+                    {
+                        state.next();
+                    }
+                    state.next(2);
+                }
                 else
                 {
                     return lexOperator(state, tokens);
                 }
+            }
+            else if (current == '#')
+            {
+                while (state.current() != '\n')
+                {
+                    state.next();
+                }
+                state.next();
             }
             else if (current == '-')
             {

--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -204,19 +204,39 @@ namespace NG::parsing
             {
                 if (state.lookAhead() == '/')
                 {
-                    while (state.current() != '\n')
+                    while (state.current() != '\n' && !state.eof())
                     {
                         state.next();
+                    }
+                    if (!state.eof())
+                    {
+                        state.nextLine();
                     }
                     state.next();
                 }
                 else if (state.lookAhead() == '*')
                 {
-                    while (!(state.current() == '*' && state.lookAhead() == '/'))
+                    // consume '/*'
+                    state.next(2);
+                    while (!state.eof())
                     {
+                        if (state.current() == '\n')
+                        {
+                            state.next();
+                            state.nextLine();
+                            continue;
+                        }
+                        if (state.current() == '*' && state.lookAhead() == '/')
+                        {
+                            state.next(2);
+                            break;
+                        }
                         state.next();
                     }
-                    state.next(2);
+                    if (state.eof())
+                    {
+                        throw LexException("Unterminated block comment");
+                    }
                 }
                 else
                 {
@@ -225,9 +245,13 @@ namespace NG::parsing
             }
             else if (current == '#')
             {
-                while (state.current() != '\n')
+                while (state.current() != '\n' && !state.eof())
                 {
                     state.next();
+                }
+                if (!state.eof())
+                {
+                    state.nextLine();
                 }
                 state.next();
             }

--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -261,6 +261,10 @@ namespace NG::parsing
                 state.next();
                 return token;
             }
+            else
+            {
+                throw LexException("Unknown token: " + std::string(1, current));
+            }
         }
         return {};
     }

--- a/src/typecheck/typecheck.cpp
+++ b/src/typecheck/typecheck.cpp
@@ -194,7 +194,7 @@ namespace NG::typecheck
                 throw TypeCheckingException("Not supported operator QUERY (?).");
             }
             default:
-                break;
+                throw TypeCheckingException("Unsupported unary operator.");
             }
         }
 

--- a/test/parsing/lexer_test.cpp
+++ b/test/parsing/lexer_test.cpp
@@ -22,7 +22,8 @@ TEST_CASE("lexer should reject unexpected tokens", "[Lexer][Token][Failure]")
 {
     Lexer lexer{LexState{"@"}};
 
-    REQUIRE_THROWS_AS(lexer.lex(), LexException);
+    REQUIRE_THROWS_MATCHES(lexer.lex(), LexException,
+                           MessageMatches(ContainsSubstring("Unknown token")));
 }
 
 TEST_CASE("lexer should produce correct positions", "[Lexer][Position][Line][Column]")
@@ -95,4 +96,20 @@ hello /* multiline comment*/
 
     REQUIRE(tokens.size() == 1);
     REQUIRE(tokens[0].type == TokenType::ID);
+}
+
+TEST_CASE("lexer should lex single line comment without newline", "[Lexer][Comment][Identifier]")
+{
+    REQUIRE(Lexer{LexState{"// comment"}}.lex().size() == 0);
+
+    REQUIRE(Lexer{LexState{"# comment"}}.lex().size() == 0);
+}
+
+TEST_CASE("lexer should fail with invalid multiline comment", "[Lexer][Comment][Identifier][Failure]")
+{
+    REQUIRE_THROWS_MATCHES(Lexer{LexState{"/*/"}}.lex(), LexException,
+                           MessageMatches(ContainsSubstring("Unterminated block comment")));
+
+    REQUIRE_THROWS_MATCHES(Lexer{LexState{"/*"}}.lex(), LexException,
+                           MessageMatches(ContainsSubstring("Unterminated block comment")));
 }

--- a/test/parsing/lexer_test.cpp
+++ b/test/parsing/lexer_test.cpp
@@ -18,6 +18,13 @@ TEST_CASE("lexer should accept tokens", "[Lexer][Token]")
     REQUIRE(state.lookAhead() == '\0');
 }
 
+TEST_CASE("lexer should reject unexpected tokens", "[Lexer][Token][Failure]")
+{
+    Lexer lexer{LexState{"@"}};
+
+    REQUIRE_THROWS_AS(lexer.lex(), LexException);
+}
+
 TEST_CASE("lexer should produce correct positions", "[Lexer][Position][Line][Column]")
 {
     Lexer lexer{LexState{">> \n   123\n\n\r\n Bc def"}};
@@ -75,8 +82,12 @@ TEST_CASE("lexer should accept assignment", "[Lexer][Assignment]")
 TEST_CASE("lexer should lex comment", "[Lexer][Comment][Identifier]")
 {
     Lexer lexer{LexState{R"(
+#!shebang like comment
 // comment
-hello
+hello /* multiline comment*/
+/**
+ *  multiline comment
+ */
 // comment
 )"}};
 

--- a/test/runtime/interpreter_test.cpp
+++ b/test/runtime/interpreter_test.cpp
@@ -271,13 +271,16 @@ assert(some_obj.a == 2);
 TEST_CASE("invalid unary operator usage", "[InterpreterTestChecking]")
 {
     // operator query not implemented
-    REQUIRE_THROWS_AS(interpret("val x = ?5;"), NotImplementedException);
+    REQUIRE_THROWS_MATCHES(interpret("val x = ?5;"), NotImplementedException,
+                           MessageMatches(ContainsSubstring("not implemented yet")));
 
     // cannot negate non-number
-    REQUIRE_THROWS_AS(interpret("val x = -false;"), RuntimeException);
+    REQUIRE_THROWS_MATCHES(interpret("val x = -false;"), RuntimeException,
+                           MessageMatches(ContainsSubstring("Cannot negate a non-number")));
 
     // cannot negate unsigned number
-    REQUIRE_THROWS_AS(interpret("val x = -1u8;"), RuntimeException);
+    REQUIRE_THROWS_MATCHES(interpret("val x = -1u8;"), RuntimeException,
+                           MessageMatches(ContainsSubstring("Cannot negate unsigned integers")));
 }
 
 TEST_CASE("unary operator usage", "[InterpreterTestChecking]")

--- a/test/runtime/interpreter_test.cpp
+++ b/test/runtime/interpreter_test.cpp
@@ -109,7 +109,7 @@ TEST_CASE("shoud be able to interpret array literal", "[InterpreterTest]")
     interpret(R"(
         val arr = [1, 2, 3, 4, 5];
 
-        print(arr);
+        assert(arr[4] == 5);
     )");
 }
 
@@ -121,13 +121,10 @@ TEST_CASE("shoud be able to interpret array index", "[InterpreterTest]")
 
 
         assert(arr[3] == 4);
-        print(arr[3]);
 
         assert(arr[4] == 5);
         arr[4] = 6;
         assert(arr[4] == 6);
-
-        print(arr);
     )");
 }
 
@@ -139,10 +136,8 @@ TEST_CASE("should be able interpret string member function", "[InterpreterTest]"
         val y = x.size();
 
         assert(y == 3);
-        print(y);
 
         assert(x.charAt(1) == 50);
-        print(x.charAt(2));
     )");
 }
 
@@ -170,42 +165,10 @@ val person = new Person {
 
 assert(person.name().size() == 9);
 
-print(person.kid.name());
+assert(person.kid.name() == "Tiny Leo");
 
-print(person.firstName);
+assert(person.firstName == "Kimmy");
 )");
-}
-
-TEST_CASE("should be able interpret exports", "[InterpreterTestImport]")
-{
-    // todo: replace with a multi module test.
-    //     interpret(R"(
-    // module hello exports (hello, a);
-
-    // fun hello() {
-    //   print("hello world");
-    // }
-
-    // val a = 1;
-
-    // module main;
-
-    // import "hello" (*);
-    // hello();
-
-    // module main2;
-
-    // import "hello" hel;
-
-    // hel.hello();
-
-    // module main3;
-
-    // import hello;
-
-    // hello.hello();
-
-    // )");
 }
 
 TEST_CASE("should be able interpret integral values", "[InterpreterTest]")
@@ -217,7 +180,7 @@ val y = 2u16;
 
 val z = x + y;
 
-print(z);
+assert(z == 3);
 
 )");
 }
@@ -233,7 +196,7 @@ val a = 3i32;
 
 val z = x + y + a;
 
-print(z);
+assert(z == 6.0);
 )");
 }
 
@@ -254,7 +217,6 @@ fun sum(n) {
 val result = sum(10);
 
 assert(result == 55);
-
 )");
 }
 
@@ -304,4 +266,29 @@ some_obj.a = 2;
 
 assert(some_obj.a == 2);
 )");
+}
+
+TEST_CASE("invalid unary operator usage", "[InterpreterTestChecking]")
+{
+    // operator query not implemented
+    REQUIRE_THROWS_AS(interpret("val x = ?5;"), NotImplementedException);
+
+    // cannot negate non-number
+    REQUIRE_THROWS_AS(interpret("val x = -false;"), RuntimeException);
+
+    // cannot negate unsigned number
+    REQUIRE_THROWS_AS(interpret("val x = -1u8;"), RuntimeException);
+}
+
+TEST_CASE("unary operator usage", "[InterpreterTestChecking]")
+{
+    interpret(R"(
+            val x = 1;
+            val y = -1;
+            assert(x == -y);
+            assert(x != y);
+            assert(!false);
+            assert(!(!true));
+            assert(0.0 > -1.0);
+        )");
 }

--- a/test/runtime/runtime_numeral_test.cpp
+++ b/test/runtime/runtime_numeral_test.cpp
@@ -19,8 +19,10 @@ TEST_CASE("test NGIntegral<T> dbz", "[Numeral][Runtime][Failure]")
     auto a = makert<NGIntegral<int>>(1);
     auto zero = makert<NGIntegral<int>>(0);
 
-    REQUIRE_THROWS_AS(a->opDividedBy(zero), NG::RuntimeException);
-    REQUIRE_THROWS_AS(a->opModulus(zero), NG::RuntimeException);
+    REQUIRE_THROWS_MATCHES(a->opDividedBy(zero), NG::RuntimeException,
+                           MessageMatches(ContainsSubstring("Division by zero")));
+    REQUIRE_THROWS_MATCHES(a->opModulus(zero), NG::RuntimeException,
+                           MessageMatches(ContainsSubstring("Modulus by zero")));
 }
 
 TEST_CASE("test NGFloatingPoint<T>", "[Numeral][Runtime][Failure]")
@@ -32,4 +34,14 @@ TEST_CASE("test NGFloatingPoint<T>", "[Numeral][Runtime][Failure]")
 
     REQUIRE(a->opLessEqual(b));
     REQUIRE(b->opGreaterEqual(a));
+}
+
+TEST_CASE("test NGInteger<T> negates", "[Numeral][Runtime][Failure]")
+{
+    auto a = makert<NGIntegral<int>>(std::numeric_limits<int>::min());
+
+    REQUIRE(a->signedness());
+
+    REQUIRE_THROWS_MATCHES(a->opNegate(), RuntimeException,
+                           MessageMatches(ContainsSubstring("Overflow on negation")));
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 #include <ast.hpp>
 #include <parser.hpp>
@@ -14,6 +15,7 @@ using namespace NG::ast;
 using namespace NG::parsing;
 
 using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
 
 inline ParseResult<ASTRef<ASTNode>> parse(const Str &source, const Str &moduleName = "[noname]", const Str &errMsg = "")
 {

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -38,6 +38,7 @@ inline ParseResult<ASTRef<ASTNode>> parse(const Str &source, const Str &moduleNa
                       location);
         }
     }
+    // debug_log("Parsed ast", (*astResult)->repr());
     return astResult;
 }
 

--- a/test/typecheck/typecheck_expression_test.cpp
+++ b/test/typecheck/typecheck_expression_test.cpp
@@ -1,0 +1,28 @@
+#include "typecheck_utils.hpp"
+
+TEST_CASE("should be able check unary expression", "[TypeCheck][UnaryExpression][ValueDefinition]")
+{
+    auto astResult = parse(R"(
+            val x: int = 100;
+            val y: int = -x;
+            val z = -5.0;
+            val result = !z;
+        )");
+
+    REQUIRE(astResult.has_value());
+
+    auto index = type_check(*astResult);
+
+    REQUIRE(index["x"]->tag() == typeinfo_tag::PRIMITIVE);
+    check_primitive_type(*index["x"], primitive_tag::I32);
+    check_primitive_type(*index["y"], primitive_tag::I32);
+    check_primitive_type(*index["z"], primitive_tag::F32);
+    check_primitive_type(*index["result"], primitive_tag::BOOL);
+}
+
+TEST_CASE("should type check unary expression fail", "[UnaryExpression][TypeCheck][Failure]")
+{
+    typecheck_failure("val x: int = -5u8;", "Invalid operand type");
+    typecheck_failure("val x: int = -false;", "Invalid operand type");
+    typecheck_failure("val x: int = ?false;", "Not supported operator");
+}

--- a/test/typecheck/typecheck_primitive_test.cpp
+++ b/test/typecheck/typecheck_primitive_test.cpp
@@ -1,12 +1,5 @@
 #include "typecheck_utils.hpp"
 
-void check_primitive_type(TypeInfo &typeInfo, primitive_tag primitive_tag)
-{
-    PrimitiveType &primitive = static_cast<PrimitiveType &>(typeInfo);
-
-    REQUIRE(primitive.primitive() == primitive_tag);
-}
-
 TEST_CASE("should be able check primitive definitions", "[TypeCheck][Primitive][ValueDefinition]")
 {
     auto astResult = parse(R"(
@@ -39,8 +32,7 @@ TEST_CASE("should type check primitives fail", "[Primitive][TypeCheck][Failure]"
     typecheck_failure("val x: bool = 2.0 > 1;", "Mismatch type on comparison operators");
     typecheck_failure("val x: bool = 2.0 >= 1;", "Mismatch type on comparison operators");
     typecheck_failure("val x: bool = 2.0 == 1;", "Mismatch type on comparison operators");
-    // todo: fix `!` lexing issue
-    // typecheck_failure("val x: bool = 2.0 != 1;", "Mismatch type on comparison operators");
+    typecheck_failure("val x: bool = 2.0 != 1;", "Mismatch type on comparison operators");
     typecheck_failure("val x = false % 1;", "Invalid type for modulus");
     typecheck_failure("val x = 1 % false;", "Mismatch type on arithmetic operation");
 }

--- a/test/typecheck/typecheck_utils.hpp
+++ b/test/typecheck/typecheck_utils.hpp
@@ -35,7 +35,8 @@ inline void typecheck_failure(const Str &source, const Str &expected_error = "")
 
 inline void check_primitive_type(TypeInfo &typeInfo, primitive_tag primitive_tag)
 {
-    PrimitiveType &primitive = static_cast<PrimitiveType &>(typeInfo);
+    REQUIRE(typeInfo.tag() == typeinfo_tag::PRIMITIVE);
+    auto &primitive = static_cast<PrimitiveType &>(typeInfo);
 
     REQUIRE(primitive.primitive() == primitive_tag);
 }

--- a/test/typecheck/typecheck_utils.hpp
+++ b/test/typecheck/typecheck_utils.hpp
@@ -32,3 +32,10 @@ inline void typecheck_failure(const Str &source, const Str &expected_error = "")
     destroyast(*astResult);
     REQUIRE(typecheckingExceptionFound);
 }
+
+inline void check_primitive_type(TypeInfo &typeInfo, primitive_tag primitive_tag)
+{
+    PrimitiveType &primitive = static_cast<PrimitiveType &>(typeInfo);
+
+    REQUIRE(primitive.primitive() == primitive_tag);
+}


### PR DESCRIPTION
- **fix(warn): fix compiler init order warning and lexer dead loop**
- **feat(lexer): multiline comment and shebang**
- **feat(unary): interpert unary operators**
- **chore(test): remove debugging code**
- **feat(typecheck): type check unary expression**

Resolves #14 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unary operators: numeric negation and logical NOT with clear error messages for unsupported uses.
  * Lexer: support for C-style block comments and line directives/shebang lines; clearer unknown-token errors.
* **Chores**
  * Iterator example updated to use "!" negation and includes a debug print.
* **Tests**
  * New and updated tests for unary operators, lexer behavior, type checking, and runtime numerals; test suite updated to run the new typecheck tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->