### PR TITLE
feat(tuple): tuple literal and destruct support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(NG_LIB_SRC
         src/runtime/NGStructuralObject.cpp
         src/runtime/NGModule.cpp
         src/runtime/NGTuple.cpp
+        src/runtime/NGUnit.cpp
         src/sysdep/process.cpp
         src/stdlib/prelude.cpp
         src/stdlib/imgui.cpp
@@ -58,6 +59,7 @@ set(NG_LIB_SRC
         src/typecheck/PrimitiveType.cpp
         src/typecheck/FunctionType.cpp
         src/typecheck/ArrayType.cpp
+        src/typecheck/TupleType.cpp
         )
 
 set(NG_TEST_SRC
@@ -84,6 +86,7 @@ set(NG_TEST_SRC
         test/typecheck/typecheck_expression_test.cpp
         test/typecheck/typecheck_array_test.cpp
         test/typecheck/typecheck_controlflow_test.cpp
+        test/typecheck/typecheck_tuple_test.cpp
 )
 
 add_executable(feature_test test/feature_test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(NG_LIB_SRC
         src/runtime/NGNumeral.cpp
         src/runtime/NGStructuralObject.cpp
         src/runtime/NGModule.cpp
+        src/runtime/NGTuple.cpp
         src/sysdep/process.cpp
         src/stdlib/prelude.cpp
         src/stdlib/imgui.cpp
@@ -64,6 +65,7 @@ set(NG_TEST_SRC
         test/parsing/lexer_keyword_test.cpp
         test/parsing/lexer_symbol_identifier_test.cpp
         test/parsing/lexer_values_test.cpp
+        test/parsing/lexer_tuple_range_test.cpp
         test/parsing/parser_test.cpp
         test/parsing/parser_function_test.cpp
         test/parsing/parser_module_import_export_test.cpp
@@ -71,6 +73,7 @@ set(NG_TEST_SRC
         test/parsing/parser_control_flow_test.cpp
         test/parsing/parser_unary_expression_test.cpp
         test/parsing/parse_composite_type_test.cpp
+        test/parsing/parse_tuple_range_test.cpp
         test/integration_test.cpp
         test/runtime/interpreter_test.cpp
         test/runtime/runtime_numeral_test.cpp

--- a/docs/design/tuples.md
+++ b/docs/design/tuples.md
@@ -1,6 +1,6 @@
 # On Design of Tuples
 
-Latest update see https://github.com/ng-lang/ng/discussions/21
+Latest update see <https://github.com/ng-lang/ng/discussions/21>
 
 
 Tuple is just series values with different type grouped together.
@@ -54,11 +54,11 @@ private string[] words = [
 ];              // 10 (or words.Length) ^0
 ```
 
-In C# usualy a Range is only used to access collections (using index operator `[]`). Not for other things like Python `range` function or Ruby's Range.
+In C# usually a Range is only used to access collections (using index operator `[]`). Not for other things like Python `range` function or Ruby's Range.
 
 In Ruby, a range can be either a generative collection. And it's even more flexible than Python's `range`. Any type that implements `#succ` method and `<=>` operator (`Comparable`), can use range operator. (Python `range` only supports integer).
 
-But there's another shortage for Ruby's Range comparing to Python. In python you can create an descending order range by specifying the third argument (`step`) in `range` as negative value, e.g. `range(10, 0, -1)` generates a range that counting down from `10` to `0` (exclusively). In Ruby you can create such object but not everying works as expected.
+But there's another shortage for Ruby's Range comparing to Python. In python you can create an descending order range by specifying the third argument (`step`) in `range` as negative value, e.g. `range(10, 0, -1)` generates a range that counting down from `10` to `0` (exclusively). In Ruby you can create such object but not everything works as expected.
 
 Compare following two code blocks:
 
@@ -94,9 +94,9 @@ end
 (1..10).reverse_each.to_a # => [10, 9, .., 1]
 ```
 
-In Rust, Range operator are pertty similar to Ruby, but use different syntax where `..` for end-exclusive, and `..=` for end inclusive.
+In Rust, Range operator are pretty similar to Ruby, but use different syntax where `..` for end-exclusive, and `..=` for end inclusive.
 
-There's no such operator in C++ or JavaScript, but they support `...` unpacking. C++ also has an fold expression that utilize `...` syntax to simplify map / reduce actions on packs (which I think that can be expanded to ranges instead). C# also have a way to unpack range, but they use `..` syntax instead.
+There's no such operator in C++ or JavaScript, but they support `...` unpacking. C++ also has a fold expression that utilize `...` syntax to simplify map / reduce actions on packs (which I think that can be expanded to ranges instead). C# also have a way to unpack range, but they use `..` syntax instead.
 
 ## Fold
 
@@ -150,7 +150,7 @@ val z = sum(x..., 0);   // same as => val z = foldr(sum, 0, x);
 
 There's another feature that might involve `...` syntax. In C, there's variadic function (for example `printf`), which use `...` for their variable length function parameters.
 
-Here we'll introduce a variadic syntax for native function declarations just now. More about varaidic functions will covered in other drafts.
+Here we'll introduce a variadic syntax for native function declarations just now. More about variadic functions will covered in other drafts.
 
 - `fun print(...) -> unit = native;` any length tuple of any types, `typeof(...)` => a tuple.
 
@@ -203,6 +203,6 @@ To allow tuple type level operations, we may also need following operators on ty
   - [ ] Fold without init `<fn>(<collection>..., _)`, Here `_` used as a place holder that `fn` will take first element in `<collection>` as `<init>`.
   - [ ] Map result can be placed into fold, `<fn_a>(<fn_b>(<collection>)..., <init>)` or
   - [ ] Map result can construct a new collection `[<fn>(<collection>)...]`. or
-  - [ ] Map result can be applyed with new map. `[<fn_a>(<fn_b>(<collection>)...)...]`
+  - [ ] Map result can be applied with new map. `[<fn_a>(<fn_b>(<collection>)...)...]`
 - [ ] Pipeline syntax on collections
   - [ ] Example `<collection> |> <map_fn>(...) |> <filter_fn>(?...) |> fold_fn(..., <init>)`

--- a/docs/design/tuples.md
+++ b/docs/design/tuples.md
@@ -1,0 +1,208 @@
+# On Design of Tuples
+
+Latest update see https://github.com/ng-lang/ng/discussions/21
+
+
+Tuple is just series values with different type grouped together.
+
+There's few convenient things for tuple:
+- used as multiple returns
+- used as multiple bindings
+- used to dynamically apply to function values
+
+Examples:
+
+```ng
+val x = (1, "a", false);
+
+
+val y: (int, string, bool) = x;
+
+
+val (a, b, c) = y;
+
+fun consume(a: int, b: string, c: bool) -> unit = native;
+
+consume(...x);   // same as `consume(a, b, c);` 
+                 //      or `consume(1, "a", false);`
+
+
+fun provide() -> (int, bool) = native;
+```
+
+## Ranges
+
+To support `...` (spread overator), we need also add `..` operator support or consider as an invalid token. Here I am considering adding it as range operator. For example, `1..10` creates a range between 1 (inclusive) and 10 (exclusive) for all integers.
+
+In Ruby,`..` considered as an end-inclusive range operator, where `...` considered as a end-exclusive one, `1...10` creates a range `[1, 2, .., 9]`. There's also a feature that using range as unary operator, `1..` creates an infinite range starting from `1`. And `..10` creates a range ends with `10`.
+
+In C#, `..` only creates an end-exclusive range, but there's another operator `^` that creates "from-end" index (Similar to Python/Ruby's negative index). Like `some_array[^2..^0]` returns last two elements from the array. "from-end" index also counting from 0, but represents not last element, but the end of the collection (since the operator is exclusive). For example:
+
+```csharp
+private string[] words = [
+                // index from start     index from end
+    "first",    // 0                    ^10
+    "second",   // 1                    ^9
+    "third",    // 2                    ^8
+    "fourth",   // 3                    ^7
+    "fifth",    // 4                    ^6
+    "sixth",    // 5                    ^5
+    "seventh",  // 6                    ^4
+    "eighth",   // 7                    ^3
+    "ninth",    // 8                    ^2
+    "tenth"     // 9                    ^1
+];              // 10 (or words.Length) ^0
+```
+
+In C# usualy a Range is only used to access collections (using index operator `[]`). Not for other things like Python `range` function or Ruby's Range.
+
+In Ruby, a range can be either a generative collection. And it's even more flexible than Python's `range`. Any type that implements `#succ` method and `<=>` operator (`Comparable`), can use range operator. (Python `range` only supports integer).
+
+But there's another shortage for Ruby's Range comparing to Python. In python you can create an descending order range by specifying the third argument (`step`) in `range` as negative value, e.g. `range(10, 0, -1)` generates a range that counting down from `10` to `0` (exclusively). In Ruby you can create such object but not everying works as expected.
+
+Compare following two code blocks:
+
+(Python)
+```python
+r = range(10, 0, -1)
+
+5 in r # => true
+
+list(r) # => [10, 9, .., 1]
+```
+
+(Ruby)
+```ruby
+# These works for ascending ranges
+(1..10).include? 5      # => true
+(1..10).cover? (1..5)   # => true
+(1..10).to_a            # => [1, 2, .., 10]
+
+r = 10..1
+
+# But these are not work
+r.include? 5    # => false
+r.cover? (5..1) # => false
+r.to_a          # => []
+
+# How ever if you use `#step` method:
+r.step(-1) do |x|
+  puts x. # => output from 10 to 1, it worked!
+end
+
+# Officially they suggest using `#reverse_each` method:
+(1..10).reverse_each.to_a # => [10, 9, .., 1]
+```
+
+In Rust, Range operator are pertty similar to Ruby, but use different syntax where `..` for end-exclusive, and `..=` for end inclusive.
+
+There's no such operator in C++ or JavaScript, but they support `...` unpacking. C++ also has an fold expression that utilize `...` syntax to simplify map / reduce actions on packs (which I think that can be expanded to ranges instead). C# also have a way to unpack range, but they use `..` syntax instead.
+
+## Fold
+
+Considering add fold expression in NG like C++ but apply to any Collections.
+
+The spread operator have different meanings depend on which kind of way use it. When used as a prefix, it's unpacking, or introduce a new multiple binding. When used as postfix, it is an operator for mapping / filtering or folding. When it used standalone, it can be treated as variadic function declaration or used in pipeline syntax for mapping / filtering / folding operand.
+
+### Case 1. Unpacking / Binding
+
+```ng
+val x = 1..2; # range
+val y = [1, 2, 3];
+
+val z = [...y]; # unpack a array then apply it to array creator
+
+val a = (1, true, "hello");
+
+val (num, fact, text) = a;
+
+val [first, ...rest] = y; # rest = [y[1], ...,  y[^1]];
+```
+
+When binding and applying (unpacking then applying to function) mismatches tuple size and array size, and function arity, raise either index out of bound error, or type checking error. This compliances with function optional parameter's rule, for a function that with default value, e.g. `fun (int, bool, string = default) -> unit`, apply a tuple `(int, bool)` to it passes the type checker.
+
+
+### Case 2. Mapping / Folding
+
+```ng
+fun plus1(x: int) -> int {
+    return x + 1;
+}
+
+val x = [1, 2, 3];
+
+// map expression
+val y = [plus1(x)...];  // same as => val y = map(plus1, x);
+
+// fold expression
+fun sum(x: int, y: int) -> int {
+    return x + y;
+}
+
+val evens = [even(x)?...]; // same as => val evens = filter(even, x);
+
+val z = sum(x..., 0);   // same as => val z = foldr(sum, 0, x);
+// or
+// val z = sum(0, x...);
+```
+
+## Variadic functions
+
+There's another feature that might involve `...` syntax. In C, there's variadic function (for example `printf`), which use `...` for their variable length function parameters.
+
+Here we'll introduce a variadic syntax for native function declarations just now. More about varaidic functions will covered in other drafts.
+
+- `fun print(...) -> unit = native;` any length tuple of any types, `typeof(...)` => a tuple.
+
+- `fun assert(...assertions: [bool]) -> native;` any length vector of bool, `typeof(assertions)` => a vector of bool
+
+To allow tuple type level operations, we may also need following operators on types:
+
+- `typeof(<expression>)` get type of an expression
+- `<tuple>.size` get arguments length of a tuple
+- `<tuple>[<n>]` get n-th element type of a tuple type
+- `fun (<types>) -> <type>` a function type.
+  - also `fun <tuple-type> -> type` 
+
+## New added syntax and features
+
+### Stage 1
+
+- [ ] Tuple literal `(<values>)`
+- [ ] Tuple type literal/annotation `(<types>)`
+- [ ] Tuple operations, `<tuple>.size`, `<tuple>.<n>`, and `<tuple>[<n>]`, and `<tuple>.<n> := <value>`
+  - [ ]  `<tuple>[a..b]` ranged index will be covered in stage 3
+- [ ] Tuple/collection unpacking syntax: `...<tuple>` or `[...vector]`
+- [ ] Multiple returns `return (<values>)`
+
+### Stage 2
+
+- [ ] Variadic native functions `<fnName>(...<argName>)`
+- [ ] Multiple `val` bindings, `val (<a>, <b>: <type>) = <tuple>;`
+- [ ] Apply function with unpacked tuple `<fnName>(...<tuple>)`
+- [ ] Enhanced tuple type support:
+  - [ ] `typeof(<expression>)` get type of an expression
+  - [ ] `<tuple>.size` get arguments length of a tuple
+  - [ ] `<tuple>.<n>` get n-th element type of a tuple type
+  - [ ] `(<types>) -> <type>` a function type.
+    - [ ] also `<tuple-type> -> type` 
+
+### Stage 3
+
+- [ ] Range `a..b`, `a..^b`, `^a..^b`, (end exclusive) and `..a`, `a..` syntax.
+- [ ] Using ranges (and from-end index) to index collections/tuples `arr[a..b]`, `arr[^a]`
+- [ ] Range as first-class collections, can be also applied to construct array: `[a..b]`
+
+### Stage 4
+
+- [ ] Fold expression on collections
+  - [ ] Map `<fn>(<collection>)...`
+  - [ ] Filter `<pred>(collection)?...`
+  - [ ] Fold right `<fn>(<collection>..., <init>)`
+  - [ ] Fold left `<fn>(<init>, <collection>...)`
+  - [ ] Fold without init `<fn>(<collection>..., _)`, Here `_` used as a place holder that `fn` will take first element in `<collection>` as `<init>`.
+  - [ ] Map result can be placed into fold, `<fn_a>(<fn_b>(<collection>)..., <init>)` or
+  - [ ] Map result can construct a new collection `[<fn>(<collection>)...]`. or
+  - [ ] Map result can be applyed with new map. `[<fn_a>(<fn_b>(<collection>)...)...]`
+- [ ] Pipeline syntax on collections
+  - [ ] Example `<collection> |> <map_fn>(...) |> <filter_fn>(?...) |> fold_fn(..., <init>)`

--- a/example/14.tuple.ng
+++ b/example/14.tuple.ng
@@ -1,0 +1,31 @@
+
+val x = (1, false, "hello");
+
+assert(x.0 == 1);
+assert(x.1 == false);
+assert(x.2 == "hello");
+
+val y = (0, ...x, 4);
+
+x.1 := true;
+
+assert(x[0] == 1);
+assert(x[1] == true);
+assert(x[2] == "hello");
+
+assert(!y[2]);
+
+val (a, b, c, ...d) = y;
+
+assert(a == 0);
+assert(b == 1);
+assert(!c);
+assert(d.size == 2);
+
+
+assert(x.size == 3);
+assert(y.size == 5);
+
+print(x);
+print(...y);
+print((a, b, c, ...d));

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -632,9 +632,8 @@ namespace NG::ast
     {
         Str name;                                    ///< The name of the binding.
         ASTRef<TypeAnnotation> annotation = nullptr; ///< The type annotation of the binding.
-        ASTRef<Expression> value = nullptr;          ///< The value of the binding, if any.
         bool spreadReceiver = false;                 ///< The indicator of whether its a spread receiver.
-        int index = -1;                              ///< The index of the binding in the tuple unpack.
+        size_t index = 0;                            ///< The index of the binding in the tuple unpack.
 
         void accept(AstVisitor *visitor) override;
 

--- a/include/intp/runtime.hpp
+++ b/include/intp/runtime.hpp
@@ -623,6 +623,30 @@ namespace NG::runtime
     };
 
     /**
+     * @brief Represents an array in the runtime.
+     */
+    struct NGTuple : NGObject
+    {
+        RuntimeRef<Vec<RuntimeRef<NGObject>>> items; ///< The items in the array.
+
+        explicit NGTuple(const Vec<RuntimeRef<NGObject>> &vec = {}) : items{makert<Vec<RuntimeRef<NGObject>>>(vec)} {}
+
+        [[nodiscard]] auto opIndex(RuntimeRef<NGObject> index) const -> RuntimeRef<NGObject> override;
+
+        auto opIndex(RuntimeRef<NGObject> index, RuntimeRef<NGObject> newValue) -> RuntimeRef<NGObject> override;
+
+        [[nodiscard]] auto show() const -> Str override;
+
+        [[nodiscard]] auto boolValue() const -> bool override;
+
+        [[nodiscard]] auto opEquals(RuntimeRef<NGObject> other) const -> bool override;
+
+        [[nodiscard]] auto type() const -> RuntimeRef<NGType> override;
+
+        auto respond(const Str &member, NGCtx context, NGInvCtx invocationContext) -> RuntimeRef<NGObject> override;
+    };
+
+    /**
      * @brief Represents a boolean in the runtime.
      */
     struct NGBoolean final : NGObject

--- a/include/intp/runtime.hpp
+++ b/include/intp/runtime.hpp
@@ -623,11 +623,11 @@ namespace NG::runtime
     };
 
     /**
-     * @brief Represents an array in the runtime.
+     * @brief Represents an tuple in the runtime.
      */
     struct NGTuple : NGObject
     {
-        RuntimeRef<Vec<RuntimeRef<NGObject>>> items; ///< The items in the array.
+        RuntimeRef<Vec<RuntimeRef<NGObject>>> items; ///< The items in the tuple.
 
         explicit NGTuple(const Vec<RuntimeRef<NGObject>> &vec = {}) : items{makert<Vec<RuntimeRef<NGObject>>>(vec)} {}
 

--- a/include/intp/runtime.hpp
+++ b/include/intp/runtime.hpp
@@ -706,11 +706,18 @@ namespace NG::runtime
         [[nodiscard]] auto show() const -> Str override;
     };
 
+    struct NGUnit : NGObject
+    {
+        [[nodiscard]] auto type() const -> RuntimeRef<NGType> override;
+        [[nodiscard]] auto show() const -> Str override;
+    };
+
     /**
      * @brief Registers a native library.
      *
      * @param moduleId The ID of the module.
      * @param handlers The handlers for the native functions.
      */
-    void register_native_library(Str moduleId, Map<Str, NGInvocable> handlers);
+    void
+    register_native_library(Str moduleId, Map<Str, NGInvocable> handlers);
 }

--- a/include/token.hpp
+++ b/include/token.hpp
@@ -46,6 +46,7 @@ namespace NG
         KEYWORD_CONTINUE,
         KEYWORD_IN,
         KEYWORD_IS,
+        KEYWORD_TYPEOF,
 
         KEYWORD_TRUE = 0x0400,
         KEYWORD_FALSE,
@@ -134,6 +135,10 @@ namespace NG
         NOT,       // !
         QUERY,     // ?
         UNDEFINED, // ???
+
+        SPREAD,         // ...
+        RANGE,          // ..
+        RANGE_INCLUSIVE, // ..=
 
         ID,
         NUMBER,

--- a/include/typecheck/typeinfo.hpp
+++ b/include/typecheck/typeinfo.hpp
@@ -215,4 +215,21 @@ namespace NG::typecheck
         auto match(const TypeInfo &other) const -> bool override;
     };
 
+    /**
+     * @brief A tuple type.
+     */
+    struct TupleType : TypeInfo
+    {
+        Vec<CheckingRef<TypeInfo>> elementTypes; ///< The element types of the tuple.
+
+        explicit TupleType(Vec<CheckingRef<TypeInfo>> elementTypes)
+            : elementTypes(std::move(elementTypes))
+        {
+        }
+
+        auto tag() const -> typeinfo_tag override;
+        auto repr() const -> Str override;
+        auto match(const TypeInfo &other) const -> bool override;
+    };
+
 }

--- a/include/typecheck/typeinfo.hpp
+++ b/include/typecheck/typeinfo.hpp
@@ -3,6 +3,7 @@
 
 #include <common.hpp>
 #include <memory>
+#include <utility>
 #include <ast.hpp>
 
 namespace NG::typecheck
@@ -231,5 +232,4 @@ namespace NG::typecheck
         auto repr() const -> Str override;
         auto match(const TypeInfo &other) const -> bool override;
     };
-
 }

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -226,6 +226,13 @@ namespace NG::ast
         virtual void visit(TupleLiteral *tuple) = 0;
 
         /**
+         * @brief Visits a unit literal.
+         *
+         * @param unit The unit literal to visit.
+         */
+        virtual void visit(UnitLiteral *unit) = 0;
+
+        /**
          * @brief Visits a typeof expression.
          *
          * @param typeofExpr The typeof expression to visit.
@@ -374,6 +381,8 @@ namespace NG::ast
         void visit(ArrayLiteral *array) override;
 
         void visit(TupleLiteral *tuple) override;
+
+        void visit(UnitLiteral *unit) override;
 
         void visit(TypeOfExpression *typeofExpr) override;
         void visit(SpreadExpression *spreadExpr) override;

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -219,6 +219,37 @@ namespace NG::ast
         virtual void visit(ArrayLiteral *array) = 0;
 
         /**
+         * @brief Visits a tuple literal.
+         *
+         * @param tuple The tuple literal to visit.
+         */
+        virtual void visit(TupleLiteral *tuple) = 0;
+
+        /**
+         * @brief Visits a typeof expression.
+         *
+         * @param typeofExpr The typeof expression to visit.
+         */
+        virtual void visit(TypeOfExpression *typeofExpr) = 0;
+
+        /**
+         * @brief Visits a spread expression.
+         *
+         * @param spreadExpr The spread expression to visit.
+         */
+        virtual void visit(SpreadExpression *spreadExpr) = 0;
+
+        /**
+         * @brief Visits a value binding statement.
+         */
+        virtual void visit(ValueBindingStatement *valBind) = 0;
+
+        /**
+         * @brief Visits a binding.
+         */
+        virtual void visit(Binding *binding) = 0;
+
+        /**
          * @brief Visits a type definition.
          *
          * @param typeDef The type definition to visit.
@@ -341,6 +372,13 @@ namespace NG::ast
         void visit(BooleanValue *boolVal) override;
 
         void visit(ArrayLiteral *array) override;
+
+        void visit(TupleLiteral *tuple) override;
+
+        void visit(TypeOfExpression *typeofExpr) override;
+        void visit(SpreadExpression *spreadExpr) override;
+        void visit(ValueBindingStatement *valBind) override;
+        void visit(Binding *binding) override;
 
         void visit(TypeDef *typeDef) override;
 

--- a/src/ast/AstVisitor.cpp
+++ b/src/ast/AstVisitor.cpp
@@ -64,6 +64,8 @@ namespace NG::ast
 
     void AstVisitor::visit(TupleLiteral *tuple) {}
 
+    void AstVisitor::visit(UnitLiteral *unit) {}
+
     void AstVisitor::visit(TypeOfExpression *typeofExpr) {}
 
     void AstVisitor::visit(SpreadExpression *spreadExpr) {}

--- a/src/ast/AstVisitor.cpp
+++ b/src/ast/AstVisitor.cpp
@@ -62,6 +62,16 @@ namespace NG::ast
 
     void AstVisitor::visit(ArrayLiteral *array) {}
 
+    void AstVisitor::visit(TupleLiteral *tuple) {}
+
+    void AstVisitor::visit(TypeOfExpression *typeofExpr) {}
+
+    void AstVisitor::visit(SpreadExpression *spreadExpr) {}
+
+    void AstVisitor::visit(ValueBindingStatement *valBind) {}
+
+    void AstVisitor::visit(Binding *binding) {}
+
     void AstVisitor::visit(IndexAccessorExpression *index) {}
 
     void AstVisitor::visit(IndexAssignmentExpression *index) {}

--- a/src/ast/DummyVisitor.cpp
+++ b/src/ast/DummyVisitor.cpp
@@ -63,6 +63,16 @@ namespace NG::ast
 
     void DummyVisitor::visit(ArrayLiteral *array) {}
 
+    void DummyVisitor::visit(TupleLiteral *tuple) {}
+
+    void DummyVisitor::visit(TypeOfExpression *typeofExpr) {}
+
+    void DummyVisitor::visit(SpreadExpression *spreadExpr) {}
+
+    void DummyVisitor::visit(ValueBindingStatement *valBind) {}
+
+    void DummyVisitor::visit(Binding *binding) {}
+
     void DummyVisitor::visit(IndexAccessorExpression *index) {}
 
     void DummyVisitor::visit(IndexAssignmentExpression *index) {}

--- a/src/ast/DummyVisitor.cpp
+++ b/src/ast/DummyVisitor.cpp
@@ -65,6 +65,8 @@ namespace NG::ast
 
     void DummyVisitor::visit(TupleLiteral *tuple) {}
 
+    void DummyVisitor::visit(UnitLiteral *unit) {}
+
     void DummyVisitor::visit(TypeOfExpression *typeofExpr) {}
 
     void DummyVisitor::visit(SpreadExpression *spreadExpr) {}

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -408,6 +408,11 @@ namespace NG::ast
         }
     }
 
+    void UnitLiteral::accept(AstVisitor *visitor)
+    {
+        visitor->visit(this);
+    }
+
     void FunctionDef::accept(AstVisitor *visitor)
     {
         visitor->visit(this);

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -566,14 +566,20 @@ namespace NG::intp
 
             switch (valBind->type)
             {
-            case BindingType::DIRECT:
-            {
-                if (valBind->bindings.size() != 1)
-                {
-                    throw RuntimeException("Invalid binding type: direct binding only allow exactly 1.");
-                }
-            }
-            break;
+            // case BindingType::DIRECT:
+            // {
+            //     if (valBind->bindings.size() != 1)
+            //     {
+            //         throw RuntimeException("Invalid binding type: direct binding only allow exactly 1.");
+            //     }
+            //     auto binding = valBind->bindings[0];
+            //     if (binding->name.empty())
+            //     {
+            //         throw RuntimeException("Direct binding requires a name");
+            //     }
+            //     context->define(binding->name, result);
+            // }
+            // break;
             case BindingType::TUPLE_UNPACK:
             {
                 auto tuple = std::dynamic_pointer_cast<NGTuple>(result);
@@ -611,7 +617,7 @@ namespace NG::intp
                     {
                         context->define(binding->name, items->at(binding->index));
                     }
-                    else
+                    else if (!binding->name.empty()) // empty spread receiver just ignores everything
                     {
                         Vec<RuntimeRef<NGObject>> values{items->begin() + binding->index, items->end()};
                         context->define(binding->name, makert<NGArray>(values));

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -488,8 +488,8 @@ namespace NG::intp
                 object = result;
                 return;
             }
-            throw new RuntimeException("Invalid spread expression, expect array or tuple, but got: " +
-                                       spreadExpression->expression->repr());
+            throw RuntimeException("Invalid spread expression, expect array or tuple, but got: " +
+                                   spreadExpression->expression->repr());
         }
 
         void visit(UnitLiteral *unit) override
@@ -576,7 +576,12 @@ namespace NG::intp
             break;
             case BindingType::TUPLE_UNPACK:
             {
-                auto items = std::dynamic_pointer_cast<NGTuple>(result)->items;
+                auto tuple = std::dynamic_pointer_cast<NGTuple>(result);
+                if (!tuple)
+                {
+                    throw RuntimeException("Tuple unpacking requires a tuple value");
+                }
+                auto items = tuple->items;
                 for (auto &&binding : valBind->bindings)
                 {
                     if (!binding->spreadReceiver)
@@ -594,7 +599,12 @@ namespace NG::intp
 
             case BindingType::ARRAY_UNPACK:
             {
-                auto items = std::dynamic_pointer_cast<NGArray>(result)->items;
+                auto array = std::dynamic_pointer_cast<NGArray>(result);
+                if (!array)
+                {
+                    throw RuntimeException("Array unpacking requires an array value");
+                }
+                auto items = array->items;
                 for (auto &&binding : valBind->bindings)
                 {
                     if (!binding->spreadReceiver)

--- a/src/intp/stupid.cpp
+++ b/src/intp/stupid.cpp
@@ -515,7 +515,7 @@ namespace NG::intp
             else
             {
                 // todo: implement Unit type
-                // context->retVal = unitValue(); // or an equivalent Unit singleton/null per your design
+                context->retVal = makert<NGUnit>(); // or an equivalent Unit singleton/null per your design
             }
         }
 

--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -398,7 +398,9 @@ namespace NG::parsing
                         tokens.push_back(token);
                         state.next(2);
                         return token;
-                    }else {
+                    }
+                    else
+                    {
                         Token token{.type = TokenType::RANGE, .repr = "..", .position = pos};
                         tokens.push_back(token);
                         state.next();

--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -115,6 +115,7 @@ namespace NG::parsing
         {"continue", TokenType::KEYWORD_CONTINUE},
         {"in", TokenType::KEYWORD_IN},
         {"is", TokenType::KEYWORD_IS},
+        {"typeof", TokenType::KEYWORD_TYPEOF},
 
         {"true", TokenType::KEYWORD_TRUE},
         {"false", TokenType::KEYWORD_FALSE},
@@ -200,6 +201,10 @@ namespace NG::parsing
         {"!", TokenType::NOT},
         {"?", TokenType::QUERY},
         {"???", TokenType::UNDEFINED},
+
+        {"...", TokenType::SPREAD},
+        {"..", TokenType::RANGE},
+        {"..=", TokenType::RANGE_INCLUSIVE},
 // include
 #include "reserved.inc"
 
@@ -377,6 +382,29 @@ namespace NG::parsing
             }
             else if (current == '.')
             {
+                if (state.lookAhead() == '.')
+                {
+                    state.next();
+                    if (state.lookAhead() == '.')
+                    {
+                        Token token{.type = TokenType::SPREAD, .repr = "...", .position = pos};
+                        tokens.push_back(token);
+                        state.next(2);
+                        return token;
+                    }
+                    else if (state.lookAhead() == '=')
+                    {
+                        Token token{.type = TokenType::RANGE_INCLUSIVE, .repr = "..=", .position = pos};
+                        tokens.push_back(token);
+                        state.next(2);
+                        return token;
+                    }else {
+                        Token token{.type = TokenType::RANGE, .repr = "..", .position = pos};
+                        tokens.push_back(token);
+                        state.next();
+                        return token;
+                    }
+                }
                 Token token{.type = TokenType::DOT, .repr = ".", .position = pos};
                 tokens.push_back(token);
                 state.next();

--- a/src/parsing/reserved.inc
+++ b/src/parsing/reserved.inc
@@ -126,7 +126,6 @@ RESERVED(try),
 RESERVED(typedef),
 RESERVED(typeid),
 RESERVED(typename),
-RESERVED(typeof),
 RESERVED(union),
 
 RESERVED(unittest),

--- a/src/runtime/NGArray.cpp
+++ b/src/runtime/NGArray.cpp
@@ -14,6 +14,10 @@ namespace NG::runtime
         }
 
         auto indexVal = NGIntegral<int32_t>::valueOf(ngInt.get());
+        if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
+        {
+            throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));
+        }
 
         return (*this->items)[indexVal];
     }
@@ -27,6 +31,10 @@ namespace NG::runtime
             throw IllegalTypeException("Not a valid index");
         }
         auto indexVal = NGIntegral<uint32_t>::valueOf(ngInt.get());
+        if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
+        {
+            throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));
+        }
 
         return (*items)[indexVal] = newValue;
     }

--- a/src/runtime/NGArray.cpp
+++ b/src/runtime/NGArray.cpp
@@ -30,7 +30,7 @@ namespace NG::runtime
         {
             throw IllegalTypeException("Not a valid index");
         }
-        auto indexVal = NGIntegral<uint32_t>::valueOf(ngInt.get());
+        auto indexVal = NGIntegral<int32_t>::valueOf(ngInt.get());
         if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
         {
             throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));

--- a/src/runtime/NGTuple.cpp
+++ b/src/runtime/NGTuple.cpp
@@ -27,7 +27,7 @@ namespace NG::runtime
         {
             throw IllegalTypeException("Not a valid index");
         }
-        auto indexVal = NGIntegral<uint32_t>::valueOf(ngInt.get());
+        auto indexVal = NGIntegral<int32_t>::valueOf(ngInt.get());
         if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
         {
             throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));

--- a/src/runtime/NGTuple.cpp
+++ b/src/runtime/NGTuple.cpp
@@ -1,0 +1,107 @@
+#include <intp/runtime.hpp>
+#include <intp/runtime_numerals.hpp>
+
+namespace NG::runtime
+{
+
+    auto NGTuple::opIndex(RuntimeRef<NGObject> index) const -> RuntimeRef<NGObject>
+    {
+        auto ngInt = std::dynamic_pointer_cast<NumeralBase>(index);
+        if (ngInt == nullptr)
+        {
+            throw IllegalTypeException("Not a valid index");
+        }
+        auto indexVal = NGIntegral<int32_t>::valueOf(ngInt.get());
+
+        return (*this->items)[indexVal];
+    };
+
+    auto NGTuple::opIndex(RuntimeRef<NGObject> index, RuntimeRef<NGObject> newValue) -> RuntimeRef<NGObject>
+    {
+        auto ngInt = std::dynamic_pointer_cast<NumeralBase>(index);
+        if (ngInt == nullptr)
+        {
+            throw IllegalTypeException("Not a valid index");
+        }
+        auto indexVal = NGIntegral<uint32_t>::valueOf(ngInt.get());
+
+        return (*items)[indexVal] = newValue;
+    };
+
+    auto NGTuple::show() const -> Str
+    {
+        Str result{};
+
+        for (const auto &item : (*this->items))
+        {
+            if (!result.empty())
+            {
+                result += ", ";
+            }
+
+            result += item->show();
+        }
+
+        return "(" + result + ")";
+    };
+
+    auto NGTuple::boolValue() const -> bool
+    {
+        return !items->empty();
+    };
+
+    auto NGTuple::opEquals(RuntimeRef<NGObject> other) const -> bool
+    {
+        if (this == other.get())
+        {
+            return true;
+        }
+        auto otherTuple = std::dynamic_pointer_cast<NGTuple>(other);
+        if (!otherTuple)
+        {
+            return false;
+        }
+        if (items->size() != otherTuple->items->size())
+        {
+            return false;
+        }
+        for (size_t i = 0; i < items->size(); ++i)
+        {
+            if (!(*items)[i]->opEquals((*otherTuple->items)[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    auto NGTuple::type() const -> RuntimeRef<NGType>
+    {
+        static RuntimeRef<NGType> tupleType = makert<NGType>(NGType{
+            .name = "Tuple",
+            .memberFunctions = {}});
+        return tupleType;
+    };
+
+    auto NGTuple::respond(const Str &member, NGCtx context, NGInvCtx invocationContext) -> RuntimeRef<NGObject>
+    {
+        if (member == "size")
+        {
+            context->retVal = makert<NGIntegral<uint32_t>>(items->size());
+            return context->retVal;
+        }
+        try
+        {
+            if (auto result = std::stoi(member); true)
+            {
+                context->retVal = this->opIndex(makert<NGIntegral<int32_t>>(result));
+                return context->retVal;
+            }
+        }
+        catch (const std::invalid_argument &)
+        {
+            // Not an integer, fall through
+        }
+        return NGObject::respond(member, context, invocationContext);
+    }
+}

--- a/src/runtime/NGTuple.cpp
+++ b/src/runtime/NGTuple.cpp
@@ -12,6 +12,10 @@ namespace NG::runtime
             throw IllegalTypeException("Not a valid index");
         }
         auto indexVal = NGIntegral<int32_t>::valueOf(ngInt.get());
+        if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
+        {
+            throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));
+        }
 
         return (*this->items)[indexVal];
     };
@@ -24,6 +28,10 @@ namespace NG::runtime
             throw IllegalTypeException("Not a valid index");
         }
         auto indexVal = NGIntegral<uint32_t>::valueOf(ngInt.get());
+        if (indexVal < 0 || static_cast<size_t>(indexVal) >= items->size())
+        {
+            throw RuntimeException("Index out of bounds: " + std::to_string(indexVal));
+        }
 
         return (*items)[indexVal] = newValue;
     };

--- a/src/runtime/NGUnit.cpp
+++ b/src/runtime/NGUnit.cpp
@@ -1,6 +1,5 @@
 
 #include <intp/runtime.hpp>
-#include <intp/runtime_numerals.hpp>
 namespace NG::runtime
 {
 
@@ -11,10 +10,10 @@ namespace NG::runtime
 
     auto NGUnit::type() const -> RuntimeRef<NGType>
     {
-        static RuntimeRef<NGType> tupleType = makert<NGType>(NGType{
+        static RuntimeRef<NGType> unitType = makert<NGType>(NGType{
             .name = "unit",
             .memberFunctions = {}});
-        return tupleType;
+        return unitType;
     }
 
 }

--- a/src/runtime/NGUnit.cpp
+++ b/src/runtime/NGUnit.cpp
@@ -1,0 +1,20 @@
+
+#include <intp/runtime.hpp>
+#include <intp/runtime_numerals.hpp>
+namespace NG::runtime
+{
+
+    auto NGUnit::show() const -> Str
+    {
+        return "unit";
+    }
+
+    auto NGUnit::type() const -> RuntimeRef<NGType>
+    {
+        static RuntimeRef<NGType> tupleType = makert<NGType>(NGType{
+            .name = "unit",
+            .memberFunctions = {}});
+        return tupleType;
+    }
+
+}

--- a/src/typecheck/TupleType.cpp
+++ b/src/typecheck/TupleType.cpp
@@ -1,0 +1,49 @@
+#include <typecheck/typecheck.hpp>
+
+namespace NG::typecheck
+{
+
+    auto TupleType::tag() const -> typeinfo_tag
+    {
+        return typeinfo_tag::TUPLE;
+    }
+
+    auto TupleType::repr() const -> Str
+    {
+        Str result = "(";
+        for (size_t i = 0; i < elementTypes.size(); ++i)
+        {
+            if (i > 0)
+            {
+                result += ", ";
+            }
+            result += elementTypes[i]->repr();
+        }
+        result += ")";
+        return result;
+    }
+
+    auto TupleType::match(const TypeInfo &other) const -> bool
+    {
+        if (other.tag() != typeinfo_tag::TUPLE)
+        {
+            return false;
+        }
+
+        const auto &otherTuple = static_cast<const TupleType &>(other);
+        if (elementTypes.size() != otherTuple.elementTypes.size())
+        {
+            return false;
+        }
+
+        for (size_t i = 0; i < elementTypes.size(); ++i)
+        {
+            if (!elementTypes[i]->match(*otherTuple.elementTypes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/typecheck/TupleType.cpp
+++ b/src/typecheck/TupleType.cpp
@@ -1,4 +1,4 @@
-#include <typecheck/typecheck.hpp>
+#include <typecheck/typeinfo.hpp>
 
 namespace NG::typecheck
 {

--- a/src/typecheck/typecheck.cpp
+++ b/src/typecheck/typecheck.cpp
@@ -809,13 +809,14 @@ namespace NG::typecheck
         {
             if (tuple->elements.empty()) [[unlikely]]
             {
-                result = makecheck<ArrayType>(makecheck<Untyped>());
+                result = makecheck<TupleType>(Vec<CheckingRef<TypeInfo>>{});
                 return;
             }
             TypeChecker checker{locals};
             Vec<CheckingRef<TypeInfo>> types{};
             for (size_t i = 0; i < tuple->elements.size(); ++i)
             {
+                checker.spreadResult.clear();
                 tuple->elements[i]->accept(&checker);
                 if (!checker.spreadResult.empty())
                 {
@@ -842,9 +843,9 @@ namespace NG::typecheck
             TypeChecker checker{locals};
             spread->expression->accept(&checker);
             auto type = checker.result;
+            spreadResult.clear();
             if (auto tup = std::dynamic_pointer_cast<TupleType>(type); tup)
             {
-                spreadResult.clear();
                 result = tup;
                 for (auto &&elemType : tup->elementTypes)
                 {
@@ -853,6 +854,7 @@ namespace NG::typecheck
             }
             else if (auto arr = std::dynamic_pointer_cast<ArrayType>(type); arr)
             {
+                // Array spread does not expand compile-time arity.
                 result = arr->elementType;
             }
             else

--- a/src/typecheck/typecheck.cpp
+++ b/src/typecheck/typecheck.cpp
@@ -35,6 +35,8 @@ namespace NG::typecheck
 
         CheckingRef<TypeInfo> result;
 
+        Vec<CheckingRef<TypeInfo>> spreadResult{};
+
         Vec<CheckingRef<TypeInfo>> contextRequirement;
 
         TypeChecker(Map<Str, CheckingRef<TypeInfo>> locals, Vec<CheckingRef<TypeInfo>> contextRequirement = {})
@@ -291,6 +293,197 @@ namespace NG::typecheck
             {
                 locals.insert_or_assign(valDefStatement->name,
                                         valType);
+            }
+        }
+
+        void visit(ValueBindingStatement *valBind) override
+        {
+            switch (valBind->type)
+            {
+            // TODO: migrate ValDefStatement to ValueBindingStatement
+            // case BindingType::DIRECT:
+            // {
+            //     if (valBind->bindings.size() != 1) [[unlikely]]
+            //     {
+            //         throw TypeCheckingException("Direct binding allows only 1 value");
+            //     }
+            //     else
+            //     {
+            //         TypeChecker checker{locals};
+            //         valBind->value->accept(&checker);
+            //         auto valType = checker.result;
+            //         auto binding = valBind->bindings[0];
+            //         if (binding->annotation)
+            //         {
+            //             binding->annotation->accept(&checker);
+            //             auto annoType = checker.result;
+            //             if (annoType->match(*valType))
+            //             {
+            //                 result = annoType;
+            //                 locals.insert_or_assign(binding->name, annoType);
+            //             }
+            //             else
+            //             {
+            //                 throw TypeCheckingException("Value Binding Type Mismatch: " +
+            //                                             valType->repr() + " to " +
+            //                                             annoType->repr());
+            //             }
+            //         }
+            //         else
+            //         {
+            //             result = valType;
+            //             locals.insert_or_assign(binding->name, valType);
+            //         }
+            //     }
+            // }
+            // break;
+            case BindingType::TUPLE_UNPACK:
+            {
+                TypeChecker checker{locals};
+                valBind->value->accept(&checker);
+                auto valType = checker.result;
+                if (auto tupleType = std::dynamic_pointer_cast<TupleType>(valType); tupleType)
+                {
+                    if (valBind->bindings.size() > tupleType->elementTypes.size())
+                    {
+                        throw TypeCheckingException("Too many bindings in tuple unpack: " +
+                                                    std::to_string(valBind->bindings.size()) + " to " +
+                                                    std::to_string(tupleType->elementTypes.size()));
+                    }
+                    for (size_t i = 0; i < valBind->bindings.size(); ++i)
+                    {
+                        auto binding = valBind->bindings[i];
+                        if (binding->spreadReceiver)
+                        {
+                            if (i != valBind->bindings.size() - 1) [[unlikely]]
+                            {
+                                throw TypeCheckingException("Spread receiver must be the last binding in tuple unpack.");
+                            }
+                            auto restTypes = Vec<CheckingRef<TypeInfo>>{};
+                            for (size_t j = i; j < tupleType->elementTypes.size(); ++j)
+                            {
+                                restTypes.push_back(tupleType->elementTypes[j]);
+                            }
+                            auto restTupleType = makecheck<TupleType>(restTypes);
+                            if (binding->annotation)
+                            {
+                                binding->annotation->accept(&checker);
+                                auto annoType = checker.result;
+                                if (annoType->match(*restTupleType))
+                                {
+                                    locals.insert_or_assign(binding->name, annoType);
+                                }
+                                else
+                                {
+                                    throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                                restTupleType->repr() + " to " +
+                                                                annoType->repr());
+                                }
+                            }
+                            else if (!binding->name.empty())
+                            {
+                                locals.insert_or_assign(binding->name, restTupleType);
+                            }
+                            break;
+                        }
+                        if (binding->annotation)
+                        {
+                            binding->annotation->accept(&checker);
+                            auto annoType = checker.result;
+                            if (annoType->match(*tupleType->elementTypes[i]))
+                            {
+                                locals.insert_or_assign(binding->name, annoType);
+                            }
+                            else
+                            {
+                                throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                            tupleType->elementTypes[i]->repr() + " to " +
+                                                            annoType->repr());
+                            }
+                        }
+                        else
+                        {
+                            locals.insert_or_assign(binding->name, (tupleType->elementTypes[i]));
+                        }
+                    }
+                }
+                else
+                {
+                    throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                valType->repr() + " to tuple");
+                }
+            }
+            break;
+            case BindingType::ARRAY_UNPACK:
+            {
+                TypeChecker checker{locals};
+                valBind->value->accept(&checker);
+                auto valType = checker.result;
+                if (auto arrayType = std::dynamic_pointer_cast<ArrayType>(valType); arrayType)
+                {
+                    for (size_t i = 0; i < valBind->bindings.size(); ++i)
+                    {
+                        auto binding = valBind->bindings[i];
+                        if (binding->spreadReceiver)
+                        {
+                            if (i != valBind->bindings.size() - 1) [[unlikely]]
+                            {
+                                throw TypeCheckingException("Spread receiver must be the last binding in array unpack.");
+                            }
+                            auto restArrayType = makecheck<ArrayType>(arrayType->elementType);
+                            if (binding->annotation)
+                            {
+                                binding->annotation->accept(&checker);
+                                auto annoType = checker.result;
+                                if (annoType->match(*restArrayType))
+                                {
+                                    locals.insert_or_assign(binding->name, annoType);
+                                }
+                                else
+                                {
+                                    throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                                restArrayType->repr() + " to " +
+                                                                annoType->repr());
+                                }
+                            }
+                            else if (!binding->name.empty())
+                            {
+                                locals.insert_or_assign(binding->name, restArrayType);
+                            }
+
+                            break;
+                        }
+                        if (binding->annotation)
+                        {
+                            binding->annotation->accept(&checker);
+                            auto annoType = checker.result;
+                            if (annoType->match(*arrayType->elementType))
+                            {
+                                locals.insert_or_assign(binding->name, annoType);
+                            }
+                            else
+                            {
+                                throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                            arrayType->elementType->repr() + " to " +
+                                                            annoType->repr());
+                            }
+                        }
+                        else
+                        {
+                            locals.insert_or_assign(binding->name, arrayType->elementType);
+                        }
+                    }
+                }
+                else
+                {
+                    throw TypeCheckingException("Value Binding Type Mismatch: " +
+                                                valType->repr() + " to array");
+                }
+            }
+            break;
+            default:
+                throw TypeCheckingException("Unexpected binding type");
+                break;
             }
         }
 
@@ -554,6 +747,20 @@ namespace NG::typecheck
                     throw TypeCheckingException("Array type expects exactly 1 type argument");
                 }
             }
+            else if (annotation->type == TypeAnnotationType::TUPLE)
+            {
+                Vec<CheckingRef<TypeInfo>> types{};
+                TypeChecker checker{locals};
+
+                for (auto &&anno : annotation->arguments)
+                {
+                    anno->accept(&checker);
+                    auto &&type = checker.result;
+                    types.push_back(type);
+                }
+                result = makecheck<TupleType>(types);
+                return;
+            }
             else
             {
                 auto it = locals.find(annotation->name);
@@ -596,6 +803,62 @@ namespace NG::typecheck
                 }
             }
             result = makecheck<ArrayType>(elemType);
+        }
+
+        void visit(TupleLiteral *tuple) override
+        {
+            if (tuple->elements.empty()) [[unlikely]]
+            {
+                result = makecheck<ArrayType>(makecheck<Untyped>());
+                return;
+            }
+            TypeChecker checker{locals};
+            Vec<CheckingRef<TypeInfo>> types{};
+            for (size_t i = 0; i < tuple->elements.size(); ++i)
+            {
+                tuple->elements[i]->accept(&checker);
+                if (!checker.spreadResult.empty())
+                {
+                    for (auto &&type : checker.spreadResult)
+                    {
+                        types.push_back(type);
+                    }
+                }
+                else
+                {
+                    types.push_back(std::move(checker.result));
+                }
+            }
+            result = makecheck<TupleType>(types);
+        }
+
+        void visit(UnitLiteral *unitLiteral) override
+        {
+            result = makecheck<PrimitiveType>(typeinfo_tag::UNIT);
+        }
+
+        void visit(SpreadExpression *spread) override
+        {
+            TypeChecker checker{locals};
+            spread->expression->accept(&checker);
+            auto type = checker.result;
+            if (auto tup = std::dynamic_pointer_cast<TupleType>(type); tup)
+            {
+                spreadResult.clear();
+                result = tup;
+                for (auto &&elemType : tup->elementTypes)
+                {
+                    spreadResult.push_back(elemType);
+                }
+            }
+            else if (auto arr = std::dynamic_pointer_cast<ArrayType>(type); arr)
+            {
+                result = arr->elementType;
+            }
+            else
+            {
+                throw TypeCheckingException("Invalid spread expression on type, expect tuple or array, got " + type->repr());
+            }
         }
 
         void visit(IndexAccessorExpression *indexAccess) override

--- a/src/typecheck/typeinfo.cpp
+++ b/src/typecheck/typeinfo.cpp
@@ -33,4 +33,48 @@ namespace NG::typecheck
     }
 
     Untyped::~Untyped() = default;
+
+    auto TupleType::tag() const -> typeinfo_tag
+    {
+        return typeinfo_tag::TUPLE;
+    }
+
+    auto TupleType::repr() const -> Str
+    {
+        Str result = "(";
+        for (size_t i = 0; i < elementTypes.size(); ++i)
+        {
+            if (i > 0)
+            {
+                result += ", ";
+            }
+            result += elementTypes[i]->repr();
+        }
+        result += ")";
+        return result;
+    }
+
+    auto TupleType::match(const TypeInfo &other) const -> bool
+    {
+        if (other.tag() != typeinfo_tag::TUPLE)
+        {
+            return false;
+        }
+
+        const auto &otherTuple = static_cast<const TupleType &>(other);
+        if (elementTypes.size() != otherTuple.elementTypes.size())
+        {
+            return false;
+        }
+
+        for (size_t i = 0; i < elementTypes.size(); ++i)
+        {
+            if (!elementTypes[i]->match(*otherTuple.elementTypes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/typecheck/typeinfo.cpp
+++ b/src/typecheck/typeinfo.cpp
@@ -33,48 +33,4 @@ namespace NG::typecheck
     }
 
     Untyped::~Untyped() = default;
-
-    auto TupleType::tag() const -> typeinfo_tag
-    {
-        return typeinfo_tag::TUPLE;
-    }
-
-    auto TupleType::repr() const -> Str
-    {
-        Str result = "(";
-        for (size_t i = 0; i < elementTypes.size(); ++i)
-        {
-            if (i > 0)
-            {
-                result += ", ";
-            }
-            result += elementTypes[i]->repr();
-        }
-        result += ")";
-        return result;
-    }
-
-    auto TupleType::match(const TypeInfo &other) const -> bool
-    {
-        if (other.tag() != typeinfo_tag::TUPLE)
-        {
-            return false;
-        }
-
-        const auto &otherTuple = static_cast<const TupleType &>(other);
-        if (elementTypes.size() != otherTuple.elementTypes.size())
-        {
-            return false;
-        }
-
-        for (size_t i = 0; i < elementTypes.size(); ++i)
-        {
-            if (!elementTypes[i]->match(*otherTuple.elementTypes[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -99,3 +99,7 @@ TEST_CASE("should run prelude as default import module", "[IntegrationLoop]")
 {
     runIntegrationTest("example/13.import_std_prelude.ng");
 }
+TEST_CASE("should run with tuple literal and accessor", "[IntegrationLoop]")
+{
+    runIntegrationTest("example/14.tuple.ng");
+}

--- a/test/parsing/lexer_tuple_range_test.cpp
+++ b/test/parsing/lexer_tuple_range_test.cpp
@@ -1,0 +1,38 @@
+
+#include "../test.hpp"
+
+using namespace NG;
+using namespace NG::parsing;
+
+TEST_CASE("lexer should accept tuple and range ralated tokens", "[Lexer][Token][Tuple][Range]")
+{
+    Lexer lexer{LexState{"a..b 1..=10 ...tup a.. ..b ^3..^1 (int, bool, float)"}};
+
+    auto &&tokens = lexer.lex();
+
+    REQUIRE(tokens.size() == 24);
+    REQUIRE(tokens[0].type == TokenType::ID);
+    REQUIRE(tokens[1].type == TokenType::RANGE);
+    REQUIRE(tokens[2].type == TokenType::ID);
+    REQUIRE(tokens[3].type == TokenType::NUMBER);
+    REQUIRE(tokens[4].type == TokenType::RANGE_INCLUSIVE);
+    REQUIRE(tokens[5].type == TokenType::NUMBER);
+    REQUIRE(tokens[6].type == TokenType::SPREAD);
+    REQUIRE(tokens[7].type == TokenType::ID);
+    REQUIRE(tokens[8].type == TokenType::ID);
+    REQUIRE(tokens[9].type == TokenType::RANGE);
+    REQUIRE(tokens[10].type == TokenType::RANGE);
+    REQUIRE(tokens[11].type == TokenType::ID);
+    REQUIRE(tokens[12].type == TokenType::CARET);
+    REQUIRE(tokens[13].type == TokenType::NUMBER);
+    REQUIRE(tokens[14].type == TokenType::RANGE);
+    REQUIRE(tokens[15].type == TokenType::CARET);
+    REQUIRE(tokens[16].type == TokenType::NUMBER);
+    REQUIRE(tokens[17].type == TokenType::LEFT_PAREN);
+    REQUIRE(tokens[18].type == TokenType::KEYWORD_INT);
+    REQUIRE(tokens[19].type == TokenType::COMMA);
+    REQUIRE(tokens[20].type == TokenType::KEYWORD_BOOL);
+    REQUIRE(tokens[21].type == TokenType::COMMA);
+    REQUIRE(tokens[22].type == TokenType::KEYWORD_FLOAT);
+    REQUIRE(tokens[23].type == TokenType::RIGHT_PAREN);   
+}

--- a/test/parsing/lexer_tuple_range_test.cpp
+++ b/test/parsing/lexer_tuple_range_test.cpp
@@ -4,7 +4,7 @@
 using namespace NG;
 using namespace NG::parsing;
 
-TEST_CASE("lexer should accept tuple and range ralated tokens", "[Lexer][Token][Tuple][Range]")
+TEST_CASE("lexer should accept tuple and range related tokens", "[Lexer][Token][Tuple][Range]")
 {
     Lexer lexer{LexState{"a..b 1..=10 ...tup a.. ..b ^3..^1 (int, bool, float)"}};
 
@@ -34,5 +34,5 @@ TEST_CASE("lexer should accept tuple and range ralated tokens", "[Lexer][Token][
     REQUIRE(tokens[20].type == TokenType::KEYWORD_BOOL);
     REQUIRE(tokens[21].type == TokenType::COMMA);
     REQUIRE(tokens[22].type == TokenType::KEYWORD_FLOAT);
-    REQUIRE(tokens[23].type == TokenType::RIGHT_PAREN);   
+    REQUIRE(tokens[23].type == TokenType::RIGHT_PAREN);
 }

--- a/test/parsing/parse_tuple_range_test.cpp
+++ b/test/parsing/parse_tuple_range_test.cpp
@@ -1,0 +1,44 @@
+#include "../test.hpp"
+
+using namespace NG;
+using namespace NG::ast;
+using namespace NG::parsing;
+
+TEST_CASE("parser should parse tuple and range values", "[Parser][Type][Literal][Tuple]")
+{
+    auto ast = parse(R"(
+        val x = (1, false, "hello");
+    )");
+    REQUIRE(ast != nullptr);
+    debug_log("Parse result:", ast->repr());
+    destroyast(ast);
+}
+
+TEST_CASE("parser should parse value like accessors", "[Parser][Type][Tuple][Accessor]")
+{
+    auto ast = parse(R"(
+        val x = tup.0;
+        val y = tup.1;
+        val z = tup.2;
+        val a = value."property";
+        val b = value.123;
+    )");
+    REQUIRE(ast != nullptr);
+    destroyast(ast);
+}
+
+TEST_CASE("parser should parse spread operator and multiple bindings", "[Parser][Type][Tuple][Accessor]")
+{
+    auto ast = parse(R"(
+        val tup = (1, 2, 3, 4, 5);
+
+        val (a, b, ...rest) = tup;
+
+        val new_tup = (0, ...tup, 6);
+        
+        val [a, b, ...c] = [1, 2, 3, 4, 5];
+    )");
+    REQUIRE(ast != nullptr);
+    debug_log("Parse result:", ast->repr());
+    destroyast(ast);
+}

--- a/test/parsing/parse_tuple_range_test.cpp
+++ b/test/parsing/parse_tuple_range_test.cpp
@@ -10,7 +10,6 @@ TEST_CASE("parser should parse tuple and range values", "[Parser][Type][Literal]
         val x = (1, false, "hello");
     )");
     REQUIRE(ast != nullptr);
-    debug_log("Parse result:", ast->repr());
     destroyast(ast);
 }
 
@@ -30,15 +29,26 @@ TEST_CASE("parser should parse value like accessors", "[Parser][Type][Tuple][Acc
 TEST_CASE("parser should parse spread operator and multiple bindings", "[Parser][Type][Tuple][Accessor]")
 {
     auto ast = parse(R"(
-        val tup = (1, 2, 3, 4, 5);
+        val tup: (i16, i32, i64, u8, i8) = (1, 2, 3, 4, 5);
 
-        val (a, b, ...rest) = tup;
+        val (a: i16, b: i32, ...rest: (i64, u8, i8)) = tup;
 
         val new_tup = (0, ...tup, 6);
         
         val [a, b, ...c] = [1, 2, 3, 4, 5];
+
+        val x = unit;
+        val z: ((int, int, int), (int, int, int)) = (c, c);
+
+        val (a, b, ...) = z;
+
     )");
     REQUIRE(ast != nullptr);
     debug_log("Parse result:", ast->repr());
     destroyast(ast);
+}
+
+TEST_CASE("parser should fail when parse invalid spread operator and multiple bindings", "[Parser][Type][Tuple][Accessor]")
+{
+    parseInvalid("val (x, ..., ) = (1, 2, 3);", "Unpacking binding must be last one");
 }

--- a/test/runtime/interpreter_test.cpp
+++ b/test/runtime/interpreter_test.cpp
@@ -293,3 +293,24 @@ TEST_CASE("unary operator usage", "[InterpreterTestChecking]")
             assert(0.0 > -1.0);
         )");
 }
+
+TEST_CASE("Tuples", "[InterpreterTestChecking]")
+{
+    interpret(R"(
+        val tup = (1, false, "hello");
+        assert(tup.0 == 1);
+        assert(tup.1 == false);
+        assert(tup.2 == "hello");
+
+        val (a, b, c) = tup;
+
+        val (d, ...e) = tup;
+
+        assert(a == d);
+
+        val [x, ...y] = [1, 2, 3, 4, 5];
+
+        assert(e.size == 2);
+        assert(y[0] == 2);
+        )");
+}

--- a/test/runtime/interpreter_test.cpp
+++ b/test/runtime/interpreter_test.cpp
@@ -306,11 +306,19 @@ TEST_CASE("Tuples", "[InterpreterTestChecking]")
 
         val (d, ...e) = tup;
 
+        val f = unit;
+
+        assert(f is unit);
+
         assert(a == d);
 
         val [x, ...y] = [1, 2, 3, 4, 5];
 
         assert(e.size == 2);
         assert(y[0] == 2);
+
+        val [z, ...] = y;
+
+        assert(z == 2);
         )");
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -26,6 +26,7 @@ inline ASTRef<ASTNode> parse(const Str &source, const Str &moduleName = "[noname
     try
     {
         auto ast = Parser(ParseState(tokens)).parse(moduleName);
+        // debug_log(ast->repr());
         return ast;
     }
     catch (const ParseException &ex)

--- a/test/typecheck/typecheck_array_test.cpp
+++ b/test/typecheck/typecheck_array_test.cpp
@@ -74,7 +74,23 @@ TEST_CASE("should type check array with spread and unpacking", "[TypeCheck][Arra
     REQUIRE(ast != nullptr);
 
     auto index = type_check(ast);
+    // element and rest checks
+    check_type_tag(*index["a"], typeinfo_tag::I32);
+    check_type_tag(*index["b"], typeinfo_tag::I32);
+    check_type_tag(*index["rest"], typeinfo_tag::ARRAY);
 
+    // arrays constructed via spread
+    check_type_tag(*index["arr2"], typeinfo_tag::ARRAY);
+    check_type_tag(*index["arr3"], typeinfo_tag::ARRAY);
+
+    // unpack with explicit rest type
+    check_type_tag(*index["d"], typeinfo_tag::I32);
+    check_type_tag(*index["e"], typeinfo_tag::I32);
+    check_type_tag(*index["f"], typeinfo_tag::ARRAY);
+
+    // unpack with explicit typed second element
+    check_type_tag(*index["g"], typeinfo_tag::I32);
+    check_type_tag(*index["h"], typeinfo_tag::I32);
     destroyast(ast);
 }
 

--- a/test/typecheck/typecheck_array_test.cpp
+++ b/test/typecheck/typecheck_array_test.cpp
@@ -60,6 +60,24 @@ TEST_CASE("should type check arrays", "[TypeCheck][Array]")
     destroyast(ast);
 }
 
+TEST_CASE("should type check array with spread and unpacking", "[TypeCheck][Array]")
+{
+    auto ast = parse(R"(
+            val arr: [int] = [1, 2, 3];
+            val [a, b, ...rest] = arr;
+            val arr2: [int] = [0, ...arr, 4, 5];
+            val arr3: [int] = [...arr, 6, 7, 8];
+            val [d, e, ...f: [int]] = arr2;
+            val [g, h: int, ...] = arr3;
+        )");
+
+    REQUIRE(ast != nullptr);
+
+    auto index = type_check(ast);
+
+    destroyast(ast);
+}
+
 TEST_CASE("should type check array fail", "[TypeCheck][Array][Failure]")
 {
     typecheck_failure("val arr: [int] = [1, 2.0, 3];", "Mismatched element type in array literal");
@@ -79,4 +97,7 @@ TEST_CASE("should type check array fail", "[TypeCheck][Array][Failure]")
     typecheck_failure("val arr: [int] = [1, 2, 3]; arr << \"hello\";", "Invalid element type for array push");
     typecheck_failure("val arr: [int] = [1, 2, 3]; arr + \"hello\";", "Unsupported operator for array types");
     typecheck_failure("val arr = 1; arr[0] := 1;", "Index assignment on non-array type");
+    typecheck_failure("val [a, b: bool, ...] = [1, 2, 3];", "Value Binding Type Mismatch: i32 to bool");
+    typecheck_failure("val [a, b, ...c: [bool]] = [1, 2, 3];", "Value Binding Type Mismatch: [i32] to [bool]");
+    typecheck_failure("val [a, b, ...c: [bool]] = 1;", "Value Binding Type Mismatch: i32 to array");
 }

--- a/test/typecheck/typecheck_tuple_test.cpp
+++ b/test/typecheck/typecheck_tuple_test.cpp
@@ -1,0 +1,48 @@
+#include "../test.hpp"
+
+#include <typecheck/typeinfo.hpp>
+#include <typecheck/typecheck.hpp>
+
+#include "typecheck_utils.hpp"
+
+using namespace NG::typecheck;
+
+TEST_CASE("should type tuples and unit", "[TypeCheck][Array]")
+{
+    auto ast = parse(R"(
+            val x: unit = unit;
+            val y: (int, unit) = (1, x);
+            val z: (string, int, unit) = ("hello", ...y);
+            val (a, b, ...f) = ("hello", ...y);
+            val (c: int, d: unit) = (1, ...f);
+            val (e, ...) = z;
+            val (i, ...j: (int, unit)) = z;
+        )");
+
+    REQUIRE(ast != nullptr);
+
+    auto index = type_check(ast);
+
+    check_type_tag(*index["x"], typeinfo_tag::UNIT);
+    check_type_tag(*index["y"], typeinfo_tag::TUPLE);
+    check_type_tag(*index["z"], typeinfo_tag::TUPLE);
+    check_type_tag(*index["a"], typeinfo_tag::STRING);
+    check_type_tag(*index["b"], typeinfo_tag::I32);
+    check_type_tag(*index["c"], typeinfo_tag::I32);
+    check_type_tag(*index["d"], typeinfo_tag::UNIT);
+    check_type_tag(*index["f"], typeinfo_tag::TUPLE);
+
+    destroyast(ast);
+}
+
+TEST_CASE("should type check tuple fail", "[TypeCheck][Tuple][Failure]")
+{
+    typecheck_failure("val arr: unit = 1;", "Value Define Type Mismatch: i32 to unit");
+    typecheck_failure("val arr: (int, bool) = 1;", "Value Define Type Mismatch: i32 to (i32, bool)");
+
+    typecheck_failure("val arr: (int, bool, string) = (1, true);", "Value Define Type Mismatch: (i32, bool) to (i32, bool, string)");
+    typecheck_failure("val (a, b, c) = (1, false);", "Too many bindings in tuple unpack: 3 to 2");
+    typecheck_failure("val (a: int, b: bool, c) = (false, false, 1);", "Value Binding Type Mismatch: bool to i32");
+    typecheck_failure("val (a: bool, ...b: (string, int)) = (false, false, 1);", "Value Binding Type Mismatch: (bool, i32) to (string, i32)");
+    typecheck_failure("val (a: bool, ...b: (string, int)) = 1;", "Value Binding Type Mismatch: i32 to tuple");
+}

--- a/test/typecheck/typecheck_tuple_test.cpp
+++ b/test/typecheck/typecheck_tuple_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace NG::typecheck;
 
-TEST_CASE("should type tuples and unit", "[TypeCheck][Array]")
+TEST_CASE("should type tuples and unit", "[TypeCheck][Tuple]")
 {
     auto ast = parse(R"(
             val x: unit = unit;
@@ -31,7 +31,8 @@ TEST_CASE("should type tuples and unit", "[TypeCheck][Array]")
     check_type_tag(*index["c"], typeinfo_tag::I32);
     check_type_tag(*index["d"], typeinfo_tag::UNIT);
     check_type_tag(*index["f"], typeinfo_tag::TUPLE);
-
+    check_type_tag(*index["i"], typeinfo_tag::STRING);
+    check_type_tag(*index["j"], typeinfo_tag::TUPLE);
     destroyast(ast);
 }
 


### PR DESCRIPTION
#22 implemented.

todo:
- type checking
- unit type and 
- variadic functions

For more please see #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces tuples: literals, indexing (e.g., tup.0), mutation, size, equality, and printing.
  - Destructuring/binding with rest (...), plus spread support in tuples, arrays, and function calls.
  - Adds unit literal and typeof operator.
  - Supports tuple type annotations.
  - Recognizes range syntax tokens (“..”, “..=”).
  - Export now includes all names from destructured definitions.

- Bug Fixes
  - Adds bounds checks for array indexing to prevent out-of-range access.

- Documentation
  - New tuple design document and a runnable tuple example (example/14.tuple.ng).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->