### PR TITLE
fix(parser): allow calls after numeric accessors

### DIFF
--- a/src/parsing/Lexer.cpp
+++ b/src/parsing/Lexer.cpp
@@ -218,7 +218,8 @@ namespace NG::parsing
 
   [[nodiscard]] inline auto isTermintator(char character) -> bool
   {
-    return character == ',' || character == ';' || character == ')' || character == ']' || character == '}';
+    return character == ',' || character == ';' || character == '(' || character == ')' || character == ']' ||
+           character == '}';
   }
 
   [[nodiscard]] inline auto withStream(LexState &state,

--- a/src/parsing/ParserImpl.cpp
+++ b/src/parsing/ParserImpl.cpp
@@ -2185,7 +2185,6 @@ namespace NG::parsing
       else if (expect(TokenType::NUMBER))
       {
         idacc->accessor = createNode<IdExpression>(numberLiteral()->repr());
-        return idacc;
       }
       else
       {

--- a/src/typecheck/typecheck.cpp
+++ b/src/typecheck/typecheck.cpp
@@ -7077,6 +7077,21 @@ namespace NG::typecheck
       Str memberName = idAccExpr->accessor->repr();
 
       CheckingRef<TypeInfo> memberType = makecheck<Untyped>();
+      auto numericMemberIndex = [&]() -> std::optional<size_t> {
+        if (memberName.empty() ||
+            !std::ranges::all_of(memberName, [](unsigned char ch) { return std::isdigit(ch) != 0; }))
+        {
+          return std::nullopt;
+        }
+        try
+        {
+          return static_cast<size_t>(std::stoull(memberName));
+        }
+        catch (const std::exception &)
+        {
+          throw TypeCheckingException("Tuple element index out of range: " + memberName, idAccExpr->pos);
+        }
+      };
 
       // Adhoc polymorphic member access on built-in collection types
       // Tuple, varargs, and contiguous sequence types support common members like .size.
@@ -7085,6 +7100,28 @@ namespace NG::typecheck
                                isSequenceType(primaryType));
       if (isCollectionType)
       {
+        if (auto tupleType = std::dynamic_pointer_cast<TupleType>(primaryType); tupleType)
+        {
+          if (auto index = numericMemberIndex(); index.has_value())
+          {
+            if (*index >= tupleType->elementTypes.size())
+            {
+              throw TypeCheckingException("Tuple element index out of range: " + memberName, idAccExpr->pos);
+            }
+            memberType = tupleType->elementTypes[*index];
+          }
+        }
+        else if (auto varargsType = std::dynamic_pointer_cast<VarargsType>(primaryType); varargsType)
+        {
+          if (auto index = numericMemberIndex(); index.has_value())
+          {
+            if (*index >= varargsType->elementTypes.size())
+            {
+              throw TypeCheckingException("Tuple element index out of range: " + memberName, idAccExpr->pos);
+            }
+            memberType = varargsType->elementTypes[*index];
+          }
+        }
         if (memberName == "size")
         {
           memberType = makecheck<PrimitiveType>(typeinfo_tag::U32);

--- a/test/parsing/parse_tuple_range_test.cpp
+++ b/test/parsing/parse_tuple_range_test.cpp
@@ -21,6 +21,7 @@ TEST_CASE("parser should parse value like accessors", "[Parser][Type][Tuple][Acc
         val z = tup.2;
         val a = value."property";
         val b = value.123;
+        val c = value.123(1, "arg");
     )");
     REQUIRE(ast != nullptr);
     destroyast(ast);

--- a/test/typecheck/typecheck_tuple_test.cpp
+++ b/test/typecheck/typecheck_tuple_test.cpp
@@ -53,6 +53,25 @@ TEST_CASE("should preserve tuple slice types", "[TypeCheck][Tuple][Range]")
   destroyast(ast);
 }
 
+TEST_CASE("should type check tuple numeric accessors", "[TypeCheck][Tuple][Accessor]")
+{
+  auto ast = parse(R"(
+            val tup: (int, string, bool) = (1, "two", true);
+            val first: int = tup.0;
+            val second: string = tup.1;
+            val third: bool = tup.2;
+        )");
+
+  REQUIRE(ast != nullptr);
+
+  auto index = type_check(ast);
+
+  check_type_tag(*index["first"], typeinfo_tag::I32);
+  check_type_tag(*index["second"], typeinfo_tag::STRING);
+  check_type_tag(*index["third"], typeinfo_tag::BOOL);
+  destroyast(ast);
+}
+
 TEST_CASE("should type check tuple fail", "[TypeCheck][Tuple][Failure]")
 {
   typecheck_failure("val arr: unit = 1;", "Value Define Type Mismatch: i32 to unit");
@@ -66,4 +85,6 @@ TEST_CASE("should type check tuple fail", "[TypeCheck][Tuple][Failure]")
                     "Value Binding Type Mismatch: (bool, i32) to (string, i32)");
   typecheck_failure("val (a: bool, ...b: (string, int)) = 1;", "Value Binding Type Mismatch: i32 to tuple");
   typecheck_failure("val bad = (1, 2)[0..3];", "Tuple slice bounds out of range");
+  typecheck_failure("val bad: bool = (1, \"two\").0;", "Value Define Type Mismatch: i32 to bool");
+  typecheck_failure("val bad = (1, \"two\").2;", "Tuple element index out of range");
 }


### PR DESCRIPTION
## Summary
- allow numeric accessors to continue into call-argument parsing
- let numeric tokens terminate before left paren so numeric accessor calls lex cleanly
- cover numeric accessor calls in parser tests

## Tests
- cmake --build build -j
- targeted ng_test filters for parser/tuple/module/const/partial-move coverage
- ctest --test-dir build -j

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member access now accepts numeric property accessors (e.g., .123) and enforces proper type/bounds for tuple-like values.

* **Bug Fixes**
  * Improved token termination so numeric literals parse correctly in more contexts.
  * Out-of-range numeric member access now raises a clear error.

* **Tests**
  * Added/extended tests for numeric property accessors, calls, and type/bounds checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ng-lang/ng/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->